### PR TITLE
Make iterators of FixedMap/EnumMap dereference to a non-assignable type

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -488,6 +488,7 @@ cc_test(
     name = "pair_view_test",
     srcs = ["test/pair_view_test.cpp"],
     deps = [
+        ":concepts",
         ":pair_view",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",

--- a/include/fixed_containers/enum_map.hpp
+++ b/include/fixed_containers/enum_map.hpp
@@ -138,7 +138,9 @@ private:
         using ConstOrMutableValueArray =
             std::conditional_t<IS_CONST, const ValueArrayType, ValueArrayType>;
         using ConstOrMutablePairView =
-            std::conditional_t<IS_CONST, PairView<const K, const V>, PairView<const K, V>>;
+            std::conditional_t<IS_CONST,
+                               pair_view_detail::AssignablePairView<const K, const V>,
+                               pair_view_detail::AssignablePairView<const K, V>>;
 
         ConstOrMutableValueArray* values_;
         ConstOrMutablePairView current_;  // Needed for liveness
@@ -175,7 +177,7 @@ private:
             // The function is tagged `const` and would add a `const` to the returned type.
             // This is usually fine, but PairView intentionally propagates its constness to each of
             // its views. Therefore, remove the `const`.
-            return const_cast<reference>(current_);
+            return const_cast<reference>(static_cast<const PairView<const K, V>&>(current_));
         }
     };
 

--- a/include/fixed_containers/fixed_map.hpp
+++ b/include/fixed_containers/fixed_map.hpp
@@ -90,7 +90,9 @@ private:
     {
         using ConstOrMutableTree = std::conditional_t<IS_CONST, const Tree, Tree>;
         using ConstOrMutablePairView =
-            std::conditional_t<IS_CONST, PairView<const K, const V>, PairView<const K, V>>;
+            std::conditional_t<IS_CONST,
+                               pair_view_detail::AssignablePairView<const K, const V>,
+                               pair_view_detail::AssignablePairView<const K, V>>;
 
         ConstOrMutableTree* tree_;
         NodeIndex current_index_;
@@ -157,7 +159,7 @@ private:
             // The function is tagged `const` and would add a `const` to the returned type.
             // This is usually fine, but PairView intentionally propagates its constness to each of
             // its views. Therefore, remove the `const`.
-            return const_cast<reference>(storage_);
+            return const_cast<reference>(static_cast<const PairView<const K, V>&>(storage_));
         }
 
         constexpr bool operator==(const PairProvider& other) const noexcept

--- a/test/enum_map_test.cpp
+++ b/test/enum_map_test.cpp
@@ -54,6 +54,10 @@ static_assert(std::is_trivially_copyable_v<ES_2::const_iterator>);
 static_assert(std::is_trivially_copyable_v<ES_2::iterator>);
 static_assert(std::is_trivially_copyable_v<ES_2::reverse_iterator>);
 static_assert(std::is_trivially_copyable_v<ES_2::const_reverse_iterator>);
+
+using STD_MAP_INT_INT = std::map<int, int>;
+static_assert(ranges::bidirectional_iterator<STD_MAP_INT_INT::iterator>);
+static_assert(ranges::bidirectional_iterator<STD_MAP_INT_INT::const_iterator>);
 }  // namespace
 
 TEST(EnumMap, DefaultConstructor)
@@ -974,6 +978,21 @@ TEST(EnumMap, Iterator_EnsureOrder)
     static_assert(std::prev(s1.end(), 2)->second() == 30);
     static_assert(std::prev(s1.end(), 3)->first() == TestEnum1::ONE);
     static_assert(std::prev(s1.end(), 3)->second() == 10);
+}
+
+TEST(EnumMap, DereferencedIteratorAssignability)
+{
+    {
+        using DereferencedIt = std::map<int, int>::iterator::value_type;
+        static_assert(NotMoveAssignable<DereferencedIt>);
+        static_assert(NotCopyAssignable<DereferencedIt>);
+    }
+
+    {
+        using DereferencedIt = EnumMap<TestEnum1, int>::iterator::value_type;
+        static_assert(NotMoveAssignable<DereferencedIt>);
+        static_assert(NotCopyAssignable<DereferencedIt>);
+    }
 }
 
 TEST(EnumMap, ReverseIteratorBasic)

--- a/test/fixed_map_test.cpp
+++ b/test/fixed_map_test.cpp
@@ -29,6 +29,15 @@ static_assert(TriviallyMoveAssignable<ES_1>);
 static_assert(ranges::bidirectional_iterator<ES_1::iterator>);
 static_assert(ranges::bidirectional_iterator<ES_1::const_iterator>);
 
+static_assert(std::is_trivially_copyable_v<ES_1::const_iterator>);
+static_assert(std::is_trivially_copyable_v<ES_1::iterator>);
+static_assert(std::is_trivially_copyable_v<ES_1::reverse_iterator>);
+static_assert(std::is_trivially_copyable_v<ES_1::const_reverse_iterator>);
+
+using STD_MAP_INT_INT = std::map<int, int>;
+static_assert(ranges::bidirectional_iterator<STD_MAP_INT_INT::iterator>);
+static_assert(ranges::bidirectional_iterator<STD_MAP_INT_INT::const_iterator>);
+
 }  // namespace
 
 TEST(FixedMap, DefaultConstructor)
@@ -897,6 +906,21 @@ TEST(FixedMap, Iterator_EnsureOrder)
     static_assert(std::prev(s1.end(), 2)->second() == 30);
     static_assert(std::prev(s1.end(), 3)->first() == 1);
     static_assert(std::prev(s1.end(), 3)->second() == 10);
+}
+
+TEST(FixedMap, DereferencedIteratorAssignability)
+{
+    {
+        using DereferencedIt = std::map<int, int>::iterator::value_type;
+        static_assert(NotMoveAssignable<DereferencedIt>);
+        static_assert(NotCopyAssignable<DereferencedIt>);
+    }
+
+    {
+        using DereferencedIt = FixedMap<int, int, 10>::iterator::value_type;
+        static_assert(NotMoveAssignable<DereferencedIt>);
+        static_assert(NotCopyAssignable<DereferencedIt>);
+    }
 }
 
 TEST(FixedMap, ReverseIteratorBasic)

--- a/test/pair_view_test.cpp
+++ b/test/pair_view_test.cpp
@@ -1,5 +1,7 @@
 #include "fixed_containers/pair_view.hpp"
 
+#include "fixed_containers/concepts.hpp"
+
 #include <gtest/gtest.h>
 
 namespace fixed_containers
@@ -82,9 +84,27 @@ TEST(PairView, References)
     static constexpr const int& ar = a;
     static constexpr const double& br = b;
 
-    constexpr PairView<const int&, const double&> p1{&ar,&br};
+    constexpr PairView<const int&, const double&> p1{&ar, &br};
 
     static_assert(5 == p1.first());
+}
+
+TEST(PairView, Assignability)
+{
+    static_assert(NotCopyAssignable<PairView<const int, double>>);
+    static_assert(NotMoveAssignable<PairView<const int, double>>);
+
+    static_assert(CopyAssignable<PairView<int, double>>);
+    static_assert(MoveAssignable<PairView<int, double>>);
+}
+
+TEST(AssignablePairView, Assignability)
+{
+    static_assert(CopyAssignable<pair_view_detail::AssignablePairView<const int, double>>);
+    static_assert(MoveAssignable<pair_view_detail::AssignablePairView<const int, double>>);
+
+    static_assert(CopyAssignable<pair_view_detail::AssignablePairView<int, double>>);
+    static_assert(MoveAssignable<pair_view_detail::AssignablePairView<int, double>>);
 }
 
 }  // namespace fixed_containers


### PR DESCRIPTION
This matches std::map's behavior

https://github.com/teslamotors/fixed-containers/issues/9