### PR TITLE
Add size deduction for FixedMap, FixedSet & FixedVector

### DIFF
--- a/include/fixed_containers/fixed_map.hpp
+++ b/include/fixed_containers/fixed_map.hpp
@@ -755,4 +755,59 @@ constexpr
     return erase_if_detail::erase_if_impl(c, predicate);
 }
 
+/**
+ * Construct a FixedMap with its capacity being deduced from the number of key-value pairs being
+ * passed.
+ */
+template <typename K,
+          typename V,
+          typename Compare = std::less<K>,
+          fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
+              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+          template <typename, std::size_t> typename StorageTemplate = FixedIndexBasedPoolStorage,
+          fixed_map_customize::FixedMapChecking<K> CheckingType,
+          std::size_t MAXIMUM_SIZE,
+          // Exposing this as a template parameter is useful for customization (for example with
+          // child classes that set the CheckingType)
+          typename FixedMapType =
+              FixedMap<K, V, MAXIMUM_SIZE, Compare, COMPACTNESS, StorageTemplate, CheckingType>>
+[[nodiscard]] constexpr FixedMapType make_fixed_map(
+    const std::pair<K, V> (&list)[MAXIMUM_SIZE],
+    const Compare& comparator = Compare{},
+    const std_transition::source_location& loc =
+        std_transition::source_location::current()) noexcept
+{
+    FixedMapType map{comparator};
+    for (const auto& item : list)
+    {
+        map.insert(item, loc);
+    }
+    return map;
+}
+
+template <typename K,
+          typename V,
+          typename Compare = std::less<K>,
+          fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
+              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+          template <typename, std::size_t> typename StorageTemplate = FixedIndexBasedPoolStorage,
+          std::size_t MAXIMUM_SIZE>
+[[nodiscard]] constexpr auto make_fixed_map(const std::pair<K, V> (&list)[MAXIMUM_SIZE],
+                                            const Compare& comparator = Compare{},
+                                            const std_transition::source_location& loc =
+                                                std_transition::source_location::current()) noexcept
+{
+    using CheckingType = fixed_map_customize::AbortChecking<K, V, MAXIMUM_SIZE>;
+    using FixedMapType =
+        FixedMap<K, V, MAXIMUM_SIZE, Compare, COMPACTNESS, StorageTemplate, CheckingType>;
+    return make_fixed_map<K,
+                          V,
+                          Compare,
+                          COMPACTNESS,
+                          StorageTemplate,
+                          CheckingType,
+                          MAXIMUM_SIZE,
+                          FixedMapType>(list, comparator, loc);
+}
+
 }  // namespace fixed_containers

--- a/include/fixed_containers/fixed_set.hpp
+++ b/include/fixed_containers/fixed_set.hpp
@@ -436,4 +436,55 @@ constexpr typename FixedSet<K, MAXIMUM_SIZE, Compare, COMPACTNESS, StorageTempla
     return erase_if_detail::erase_if_impl(c, predicate);
 }
 
+/**
+ * Construct a FixedSet with its capacity being deduced from the number of items being passed.
+ */
+template <typename K,
+          typename Compare = std::less<K>,
+          fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
+              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+          template <typename, std::size_t> typename StorageTemplate = FixedIndexBasedPoolStorage,
+          fixed_set_customize::FixedSetChecking<K> CheckingType,
+          std::size_t MAXIMUM_SIZE,
+          // Exposing this as a template parameter is useful for customization (for example with
+          // child classes that set the CheckingType)
+          typename FixedSetType =
+              FixedSet<K, MAXIMUM_SIZE, Compare, COMPACTNESS, StorageTemplate, CheckingType>>
+[[nodiscard]] constexpr FixedSetType make_fixed_set(
+    const K (&list)[MAXIMUM_SIZE],
+    const Compare& comparator = Compare{},
+    const std_transition::source_location& loc =
+        std_transition::source_location::current()) noexcept
+{
+    FixedSetType set{comparator};
+    for (const auto& item : list)
+    {
+        set.insert(item, loc);
+    }
+    return set;
+}
+
+template <typename K,
+          typename Compare = std::less<K>,
+          fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
+              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+          template <typename, std::size_t> typename StorageTemplate = FixedIndexBasedPoolStorage,
+          std::size_t MAXIMUM_SIZE>
+[[nodiscard]] constexpr auto make_fixed_set(const K (&list)[MAXIMUM_SIZE],
+                                            const Compare& comparator = Compare{},
+                                            const std_transition::source_location& loc =
+                                                std_transition::source_location::current()) noexcept
+{
+    using CheckingType = fixed_set_customize::AbortChecking<K, MAXIMUM_SIZE>;
+    using FixedSetType =
+        FixedSet<K, MAXIMUM_SIZE, Compare, COMPACTNESS, StorageTemplate, CheckingType>;
+    return make_fixed_set<K,
+                          Compare,
+                          COMPACTNESS,
+                          StorageTemplate,
+                          CheckingType,
+                          MAXIMUM_SIZE,
+                          FixedSetType>(list, comparator, loc);
+}
+
 }  // namespace fixed_containers

--- a/include/fixed_containers/fixed_vector.hpp
+++ b/include/fixed_containers/fixed_vector.hpp
@@ -1005,4 +1005,37 @@ constexpr typename FixedVector<T, MAXIMUM_SIZE, CheckingType>::size_type erase_i
     return original_size - c.size();
 }
 
+/**
+ * Construct a FixedVector with its capacity being deduced from the number of items being passed.
+ */
+template <typename T,
+          fixed_vector_customize::FixedVectorChecking CheckingType,
+          std::size_t MAXIMUM_SIZE,
+          // Exposing this as a template parameter is useful for customization (for example with
+          // child classes that set the CheckingType)
+          typename FixedVectorType = FixedVector<T, MAXIMUM_SIZE, CheckingType>>
+[[nodiscard]] constexpr FixedVectorType make_fixed_vector(
+    const T (&list)[MAXIMUM_SIZE],
+    const std_transition::source_location& loc =
+        std_transition::source_location::current()) noexcept
+{
+    FixedVectorType vector{};
+    for (const auto& item : list)
+    {
+        vector.push_back(item, loc);
+    }
+    return vector;
+}
+
+template <typename T, std::size_t MAXIMUM_SIZE>
+[[nodiscard]] constexpr auto make_fixed_vector(
+    const T (&list)[MAXIMUM_SIZE],
+    const std_transition::source_location& loc =
+        std_transition::source_location::current()) noexcept
+{
+    using CheckingType = fixed_vector_customize::AbortChecking<T, MAXIMUM_SIZE>;
+    using FixedVectorType = FixedVector<T, MAXIMUM_SIZE, CheckingType>;
+    return make_fixed_vector<T, CheckingType, MAXIMUM_SIZE, FixedVectorType>(list, loc);
+}
+
 }  // namespace fixed_containers

--- a/test/fixed_map_test.cpp
+++ b/test/fixed_map_test.cpp
@@ -95,6 +95,16 @@ TEST(FixedMap, OperatorBracket_Constexpr)
     static_assert(s1.contains(4));
 }
 
+TEST(FixedMap, MaxSizeDeduction)
+{
+    constexpr auto s1 = make_fixed_map({std::pair{30, 30}, std::pair{31, 54}});
+    static_assert(s1.size() == 2);
+    static_assert(s1.max_size() == 2);
+    static_assert(s1.contains(30));
+    static_assert(s1.contains(31));
+    static_assert(!s1.contains(32));
+}
+
 TEST(FixedMap, OperatorBracket_NonConstexpr)
 {
     FixedMap<int, int, 10> s1{};

--- a/test/fixed_set_test.cpp
+++ b/test/fixed_set_test.cpp
@@ -173,6 +173,16 @@ TEST(FixedSet, EmptySizeFull)
     static_assert(!s4.full());
 }
 
+TEST(FixedSet, MaxSizeDeduction)
+{
+    constexpr auto s1 = make_fixed_set({30, 31});
+    static_assert(s1.size() == 2);
+    static_assert(s1.max_size() == 2);
+    static_assert(s1.contains(30));
+    static_assert(s1.contains(31));
+    static_assert(!s1.contains(32));
+}
+
 TEST(FixedSet, Insert)
 {
     constexpr auto s1 = []()

--- a/test/fixed_vector_test.cpp
+++ b/test/fixed_vector_test.cpp
@@ -369,6 +369,18 @@ TEST(FixedVector, Initializer)
     EXPECT_TRUE(are_equal(v2, std::array{66, 55}));
 }
 
+TEST(FixedVector, MaxSizeDeduction)
+{
+    constexpr auto v1 = make_fixed_vector({10, 11, 12, 13, 14});
+    static_assert(v1.size() == 5);
+    static_assert(v1.max_size() == 5);
+    static_assert(v1[0] == 10);
+    static_assert(v1[1] == 11);
+    static_assert(v1[2] == 12);
+    static_assert(v1[3] == 13);
+    static_assert(v1[4] == 14);
+}
+
 TEST(FixedVector, CountConstructor)
 {
     // Caution: Using braces calls initializer list ctor!


### PR DESCRIPTION
Add functions `make_fixed_map`, `make_fixed_set` and `make_fixed_vector` to deduce the size of their container at compile time.

When it's known that a container won't need to grow at runtime, it is now possible to create the container without specifying its maximum size, and its maximum size will be deduced to be the number of items passed to the `make_fixed_[map/set/vector]` function.

The `SIZE` template parameter in these functions has been pushed down as far as possible to make it possible to change other template parameters without having to specify the size.

Before:
```cpp
FixedVector<int, 3> vector{1, 2, 3};
```

After:
```cpp
auto v = make_fixed_vector<int>({1, 2, 3});
```

And now even the type can be deduced:
```cpp
auto v = make_fixed_vector({1, 2, 3});
```