### PR TITLE
Remove full() members. Introduce is_full() free functions instead

### DIFF
--- a/include/fixed_containers/fixed_map.hpp
+++ b/include/fixed_containers/fixed_map.hpp
@@ -312,7 +312,6 @@ public:
 
     [[nodiscard]] constexpr std::size_t size() const noexcept { return tree_.size(); }
     [[nodiscard]] constexpr bool empty() const noexcept { return tree_.empty(); }
-    [[nodiscard]] constexpr bool full() const noexcept { return tree_.full(); }
 
     constexpr void clear() noexcept { tree_.clear(); }
 
@@ -711,7 +710,7 @@ private:
 
     constexpr void check_not_full(const std_transition::source_location& loc) const
     {
-        if (preconditions::test(!full()))
+        if (preconditions::test(!tree_.full()))
         {
             CheckingType::length_error(MAXIMUM_SIZE + 1, loc);
         }
@@ -732,6 +731,27 @@ private:
         return {create_const_iterator(l), create_const_iterator(r)};
     }
 };
+
+template <class K,
+          class V,
+          std::size_t MAXIMUM_SIZE,
+          class Compare,
+          fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS,
+          template <class /*Would be IsFixedIndexBasedStorage but gcc doesn't like the constraints
+here. clang accepts it */
+                    ,
+                    std::size_t>
+          typename StorageTemplate,
+          fixed_map_customize::FixedMapChecking<K> CheckingType>
+constexpr
+    typename FixedMap<K, V, MAXIMUM_SIZE, Compare, COMPACTNESS, StorageTemplate, CheckingType>::
+        size_type
+        is_full(
+            const FixedMap<K, V, MAXIMUM_SIZE, Compare, COMPACTNESS, StorageTemplate, CheckingType>&
+                c)
+{
+    return c.size() >= c.max_size();
+}
 
 template <class K,
           class V,

--- a/include/fixed_containers/fixed_set.hpp
+++ b/include/fixed_containers/fixed_set.hpp
@@ -185,7 +185,6 @@ public:
 
     [[nodiscard]] constexpr std::size_t size() const noexcept { return tree_.size(); }
     [[nodiscard]] constexpr bool empty() const noexcept { return tree_.empty(); }
-    [[nodiscard]] constexpr bool full() const noexcept { return tree_.full(); }
 
     constexpr void clear() noexcept { tree_.clear(); }
 
@@ -402,7 +401,7 @@ private:
 
     constexpr void check_not_full(const std_transition::source_location& loc) const
     {
-        if (preconditions::test(!full()))
+        if (preconditions::test(!tree_.full()))
         {
             CheckingType::length_error(MAXIMUM_SIZE + 1, loc);
         }
@@ -416,6 +415,23 @@ private:
         return {create_const_iterator(l), create_const_iterator(r)};
     }
 };
+
+template <class K,
+          std::size_t MAXIMUM_SIZE,
+          class Compare,
+          fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS,
+          template <class /*Would be IsFixedIndexBasedStorage but gcc doesn't like the constraints
+here. clang accepts it */
+                    ,
+                    std::size_t>
+          typename StorageTemplate,
+          fixed_set_customize::FixedSetChecking<K> CheckingType>
+constexpr typename FixedSet<K, MAXIMUM_SIZE, Compare, COMPACTNESS, StorageTemplate, CheckingType>::
+    size_type
+    is_full(const FixedSet<K, MAXIMUM_SIZE, Compare, COMPACTNESS, StorageTemplate, CheckingType>& c)
+{
+    return c.size() >= c.max_size();
+}
 
 template <class K,
           std::size_t MAXIMUM_SIZE,

--- a/include/fixed_containers/fixed_vector.hpp
+++ b/include/fixed_containers/fixed_vector.hpp
@@ -568,7 +568,6 @@ public:
      */
     [[nodiscard]] constexpr std::size_t size() const noexcept { return size_; }
     [[nodiscard]] constexpr bool empty() const noexcept { return size_ == 0; }
-    [[nodiscard]] constexpr bool full() const noexcept { return size_ >= MAXIMUM_SIZE; }
 
     /**
      * Equality.
@@ -714,7 +713,7 @@ private:
 
     constexpr void check_not_full(const std_transition::source_location& loc) const
     {
-        if (preconditions::test(!full()))
+        if (preconditions::test(size_ < MAXIMUM_SIZE))
         {
             Checking::length_error(MAXIMUM_SIZE + 1, loc);
         }
@@ -986,6 +985,13 @@ template <typename T,
               fixed_vector_customize::AbortChecking<T, MAXIMUM_SIZE>>
 using FixedVector =
     fixed_vector_detail::specializations::FixedVector<T, MAXIMUM_SIZE, CheckingType>;
+
+template <typename T, std::size_t MAXIMUM_SIZE, typename CheckingType>
+constexpr typename FixedVector<T, MAXIMUM_SIZE, CheckingType>::size_type is_full(
+    const FixedVector<T, MAXIMUM_SIZE, CheckingType>& c)
+{
+    return c.size() >= c.max_size();
+}
 
 template <typename T, std::size_t MAXIMUM_SIZE, typename CheckingType, typename U>
 constexpr typename FixedVector<T, MAXIMUM_SIZE, CheckingType>::size_type erase(

--- a/test/fixed_map_test.cpp
+++ b/test/fixed_map_test.cpp
@@ -72,10 +72,10 @@ TEST(FixedMap, EmptySizeFull)
     static_assert(s2.empty());
 
     constexpr FixedMap<int, int, 2> s3{{2, 20}, {4, 40}};
-    static_assert(s3.full());
+    static_assert(is_full(s3));
 
     constexpr FixedMap<int, int, 5> s4{{2, 20}, {4, 40}};
-    static_assert(!s4.full());
+    static_assert(!is_full(s4));
 }
 
 TEST(FixedMap, OperatorBracket_Constexpr)

--- a/test/fixed_set_test.cpp
+++ b/test/fixed_set_test.cpp
@@ -166,11 +166,11 @@ TEST(FixedSet, EmptySizeFull)
 
     constexpr FixedSet<int, 2> s3{2, 4};
     static_assert(s3.size() == 2);
-    static_assert(s3.full());
+    static_assert(is_full(s3));
 
     constexpr FixedSet<int, 5> s4{2, 4};
     static_assert(s4.size() == 2);
-    static_assert(!s4.full());
+    static_assert(!is_full(s4));
 }
 
 TEST(FixedSet, MaxSizeDeduction)

--- a/test/fixed_vector_test.cpp
+++ b/test/fixed_vector_test.cpp
@@ -987,11 +987,11 @@ TEST(FixedVector, Full)
     }();
 
     static_assert(are_equal(v1, std::array<int, 4>{100, 100, 100, 100}));
-    static_assert(v1.full());
+    static_assert(is_full(v1));
     static_assert(v1.size() == 4);
     static_assert(v1.capacity() == 4);
 
-    EXPECT_TRUE(v1.full());
+    EXPECT_TRUE(is_full(v1));
 }
 
 TEST(FixedVector, Span)


### PR DESCRIPTION
This is done to comform with the std API that does not have these members.