### PR TITLE
libc++ doesn't support `std::map<int, const int&>`

### DIFF
--- a/test/enum_map_test.cpp
+++ b/test/enum_map_test.cpp
@@ -1228,6 +1228,7 @@ static constexpr int INT_VALUE_30 = 30;
 TEST(EnumMap, ConstRef)
 {
     {
+#ifndef _LIBCPP_VERSION
         std::map<TestEnum1, const int&> s{{TestEnum1::ONE, INT_VALUE_10}};
         s.insert({TestEnum1::TWO, INT_VALUE_20});
         s.emplace(TestEnum1::THREE, INT_VALUE_30);
@@ -1243,6 +1244,7 @@ TEST(EnumMap, ConstRef)
         ASSERT_TRUE(!s.contains(TestEnum1::FOUR));
 
         ASSERT_EQ(INT_VALUE_10, s.at(TestEnum1::ONE));
+#endif
     }
 
     {

--- a/test/fixed_map_test.cpp
+++ b/test/fixed_map_test.cpp
@@ -1212,6 +1212,7 @@ static constexpr int INT_VALUE_30 = 30;
 TEST(FixedMap, ConstRef)
 {
     {
+#ifndef _LIBCPP_VERSION
         std::map<int, const int&> s{{1, INT_VALUE_10}};
         s.insert({2, INT_VALUE_20});
         s.emplace(3, INT_VALUE_30);
@@ -1227,6 +1228,7 @@ TEST(FixedMap, ConstRef)
         ASSERT_TRUE(!s.contains(4));
 
         ASSERT_EQ(INT_VALUE_10, s.at(1));
+#endif
     }
 
     {


### PR DESCRIPTION
Specifically, the assignment `s_copy = s;` doesn't work, because it's trying to use the assignment operator of a pair where one of the members has reference type. Classes with reference members have their assignment operators defaulted as deleted.