### PR TITLE
Clang: Add -Wno-poison-system-directories

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,3 +31,5 @@ build --copt -Wno-padded
 # due to gtest
 build:clang --copt -Wno-exit-time-destructors
 build:clang --copt -Wno-used-but-marked-unused
+#
+build:clang --copt -Wno-poison-system-directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ if(${USING_CLANG})
         -Wno-ctad-maybe-unsupported
 
         -Wno-padded
+        -Wno-poison-system-directories
     )
 elseif(MSVC)
     SET(DIAGNOSTIC_FLAGS ${DIAGNOSTIC_FLAGS}


### PR DESCRIPTION
Before this patch, Clang trunk gives:

    [  2%] Building CXX object CMakeFiles/string_literal_test.dir/test/string_literal_test.cpp.o
    error: include location '/usr/local/include' is unsafe for cross-compilation
    [-Werror,-Wpoison-system-directories]
    1 error generated.

Better would be to replace -Weverything with -Wall -Wextra (https://quuxplusone.github.io/blog/2018/12/06/dont-use-weverything/)