### PR TITLE
Remove magic-enum dependency from everything except the enum containers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -203,9 +203,6 @@ cc_library(
     name = "iterator_utils",
     hdrs = ["include/fixed_containers/iterator_utils.hpp"],
     includes = ["include"],
-    deps = [
-        ":enum_utils"
-    ],
     copts = ["-std=c++20"],
 )
 

--- a/include/fixed_containers/enum_map.hpp
+++ b/include/fixed_containers/enum_map.hpp
@@ -206,13 +206,12 @@ private:
 
 public:
     using const_iterator =
-        IteratorImpl<IteratorConstness::CONSTANT_ITERATOR(), IteratorDirection::FORWARD()>;
-    using iterator =
-        IteratorImpl<IteratorConstness::MUTABLE_ITERATOR(), IteratorDirection::FORWARD()>;
+        IteratorImpl<IteratorConstness::CONSTANT_ITERATOR, IteratorDirection::FORWARD>;
+    using iterator = IteratorImpl<IteratorConstness::MUTABLE_ITERATOR, IteratorDirection::FORWARD>;
     using const_reverse_iterator =
-        IteratorImpl<IteratorConstness::CONSTANT_ITERATOR(), IteratorDirection::REVERSE()>;
+        IteratorImpl<IteratorConstness::CONSTANT_ITERATOR, IteratorDirection::REVERSE>;
     using reverse_iterator =
-        IteratorImpl<IteratorConstness::MUTABLE_ITERATOR(), IteratorDirection::REVERSE()>;
+        IteratorImpl<IteratorConstness::MUTABLE_ITERATOR, IteratorDirection::REVERSE>;
     using size_type = typename KeyArrayType::size_type;
     using difference_type = typename KeyArrayType::difference_type;
 

--- a/include/fixed_containers/enum_set.hpp
+++ b/include/fixed_containers/enum_set.hpp
@@ -133,13 +133,13 @@ private:
     using IteratorImpl = IndexRangePredicateIterator<IndexPredicate,
                                                      ReferenceProvider,
                                                      ReferenceProvider,
-                                                     IteratorConstness::CONSTANT_ITERATOR(),
+                                                     IteratorConstness::CONSTANT_ITERATOR,
                                                      DIRECTION>;
 
 public:
-    using const_iterator = IteratorImpl<IteratorDirection::FORWARD()>;
+    using const_iterator = IteratorImpl<IteratorDirection::FORWARD>;
     using iterator = const_iterator;
-    using const_reverse_iterator = IteratorImpl<IteratorDirection::REVERSE()>;
+    using const_reverse_iterator = IteratorImpl<IteratorDirection::REVERSE>;
     using reverse_iterator = const_reverse_iterator;
     using size_type = typename KeyArrayType::size_type;
     using difference_type = typename KeyArrayType::difference_type;

--- a/include/fixed_containers/fixed_map.hpp
+++ b/include/fixed_containers/fixed_map.hpp
@@ -58,7 +58,7 @@ template <class K,
           std::size_t MAXIMUM_SIZE,
           class Compare = std::less<K>,
           fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
-              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
           template <class /*Would be IsFixedIndexBasedStorage but gcc doesn't like the constraints
                              here. clang accepts it */
                     ,
@@ -203,12 +203,12 @@ private:
 
 public:
     using const_iterator =
-        Iterator<IteratorConstness::CONSTANT_ITERATOR(), IteratorDirection::FORWARD()>;
-    using iterator = Iterator<IteratorConstness::MUTABLE_ITERATOR(), IteratorDirection::FORWARD()>;
+        Iterator<IteratorConstness::CONSTANT_ITERATOR, IteratorDirection::FORWARD>;
+    using iterator = Iterator<IteratorConstness::MUTABLE_ITERATOR, IteratorDirection::FORWARD>;
     using const_reverse_iterator =
-        Iterator<IteratorConstness::CONSTANT_ITERATOR(), IteratorDirection::REVERSE()>;
+        Iterator<IteratorConstness::CONSTANT_ITERATOR, IteratorDirection::REVERSE>;
     using reverse_iterator =
-        Iterator<IteratorConstness::MUTABLE_ITERATOR(), IteratorDirection::REVERSE()>;
+        Iterator<IteratorConstness::MUTABLE_ITERATOR, IteratorDirection::REVERSE>;
     using size_type = typename Tree::size_type;
     using difference_type = typename Tree::difference_type;
 
@@ -794,7 +794,7 @@ template <typename K,
           typename V,
           typename Compare = std::less<K>,
           fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
-              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
           template <typename, std::size_t> typename StorageTemplate = FixedIndexBasedPoolStorage,
           fixed_map_customize::FixedMapChecking<K> CheckingType,
           std::size_t MAXIMUM_SIZE,
@@ -820,7 +820,7 @@ template <typename K,
           typename V,
           typename Compare = std::less<K>,
           fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
-              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
           template <typename, std::size_t> typename StorageTemplate = FixedIndexBasedPoolStorage,
           std::size_t MAXIMUM_SIZE>
 [[nodiscard]] constexpr auto make_fixed_map(const std::pair<K, V> (&list)[MAXIMUM_SIZE],

--- a/include/fixed_containers/fixed_red_black_tree.hpp
+++ b/include/fixed_containers/fixed_red_black_tree.hpp
@@ -1012,7 +1012,7 @@ template <class K,
           std::size_t MAXIMUM_SIZE,
           class Compare = std::less<K>,
           RedBlackTreeNodeColorCompactness COMPACTNESS =
-              RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+              RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
           template <class /*Would be IsFixedIndexBasedStorage but gcc doesn't like the constraints
                            here. clang accepts it */
                     ,
@@ -1025,7 +1025,7 @@ template <class K,
           std::size_t MAXIMUM_SIZE,
           class Compare = std::less<K>,
           RedBlackTreeNodeColorCompactness COMPACTNESS =
-              RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+              RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
           template <IsFixedIndexBasedStorage, std::size_t> typename StorageTemplate =
               FixedIndexBasedPoolStorage>
 using FixedRedBlackTreeSet =

--- a/include/fixed_containers/fixed_red_black_tree_nodes.hpp
+++ b/include/fixed_containers/fixed_red_black_tree_nodes.hpp
@@ -1,43 +1,18 @@
 #pragma once
 
 #include "fixed_containers/concepts.hpp"
-#include "fixed_containers/enum_utils.hpp"
 #include "fixed_containers/fixed_red_black_tree_types.hpp"
 #include "fixed_containers/value_or_reference_storage.hpp"
 
 #include <utility>
 
-namespace fixed_containers::fixed_red_black_tree_detail::detail
-{
-enum class RedBlackTreeNodeColorCompactnessBackingEnum : bool
-{
-    DEDICATED_COLOR,
-    EMBEDDED_COLOR,
-};
-}  // namespace fixed_containers::fixed_red_black_tree_detail::detail
-
 namespace fixed_containers::fixed_red_black_tree_detail
 {
-class RedBlackTreeNodeColorCompactness
-  : public rich_enums::SkeletalRichEnum<RedBlackTreeNodeColorCompactness,
-                                        detail::RedBlackTreeNodeColorCompactnessBackingEnum>
+enum class RedBlackTreeNodeColorCompactness : bool
 {
-    friend SkeletalRichEnum::ValuesFriend;
-    using SkeletalRichEnum::SkeletalRichEnum;
-
-public:
-    static constexpr const std::array<RedBlackTreeNodeColorCompactness, count()>& values();
-
-    FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(RedBlackTreeNodeColorCompactness,
-                                                   DEDICATED_COLOR)
-    FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(RedBlackTreeNodeColorCompactness, EMBEDDED_COLOR)
+    DEDICATED_COLOR = false,
+    EMBEDDED_COLOR = true,
 };
-constexpr const std::array<RedBlackTreeNodeColorCompactness,
-                           RedBlackTreeNodeColorCompactness::count()>&
-RedBlackTreeNodeColorCompactness::values()
-{
-    return rich_enums::SkeletalRichEnumValues<RedBlackTreeNodeColorCompactness>::VALUES;
-}
 
 template <class T>
 concept IsRedBlackTreeNode = requires(

--- a/include/fixed_containers/fixed_red_black_tree_storage.hpp
+++ b/include/fixed_containers/fixed_red_black_tree_storage.hpp
@@ -52,17 +52,11 @@ template <class K,
           typename StorageTemplate>
 class FixedRedBlackTreeStorage
 {
-    // msvc WORKAROUND: "Error C2891 'CONSTNESS' : cannot take the address of a template parameter"
-    // Explanation:
-    // "You can't take the address of a template parameter unless it is an lvalue. Type parameters
-    // are not lvalues because they have no address" To work around that, force l-values.
-    static constexpr RedBlackTreeNodeColorCompactness COMPACTNESS_LVALUE = COMPACTNESS;
-
 public:
     using KeyType = K;
     using ValueType = V;
     using NodeType =
-        std::conditional_t<COMPACTNESS_LVALUE == RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+        std::conditional_t<COMPACTNESS == RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
                            CompactRedBlackTreeNode<K, V>,
                            DefaultRedBlackTreeNode<K, V>>;
     static constexpr bool HAS_ASSOCIATED_VALUE = NodeType::HAS_ASSOCIATED_VALUE;

--- a/include/fixed_containers/fixed_red_black_tree_view.hpp
+++ b/include/fixed_containers/fixed_red_black_tree_view.hpp
@@ -194,10 +194,10 @@ public:
 
             switch (compactness_)
             {
-            case Compactness::DEDICATED_COLOR(): /* default node */
+            case Compactness::DEDICATED_COLOR: /* default node */
                 return *reinterpret_cast<const NodeIndex*>(parent_idx_ptr);
 
-            case Compactness::EMBEDDED_COLOR(): /* compact node*/
+            case Compactness::EMBEDDED_COLOR: /* compact node*/
                 return reinterpret_cast<const NodeIndexWithColorEmbeddedInTheMostSignificantBit*>(
                            parent_idx_ptr)
                     ->get_index();
@@ -354,10 +354,10 @@ public:
             std::size_t base_node_size_bytes = 0;
             switch (compactness_)
             {
-            case Compactness::DEDICATED_COLOR():
+            case Compactness::DEDICATED_COLOR:
                 base_node_size_bytes = sizeof(DefaultRedBlackTreeNode<uintptr_t>);
                 break;
-            case Compactness::EMBEDDED_COLOR():
+            case Compactness::EMBEDDED_COLOR:
                 base_node_size_bytes = sizeof(CompactRedBlackTreeNode<uintptr_t>);
                 break;
             }

--- a/include/fixed_containers/fixed_set.hpp
+++ b/include/fixed_containers/fixed_set.hpp
@@ -47,7 +47,7 @@ template <class K,
           std::size_t MAXIMUM_SIZE,
           class Compare = std::less<K>,
           fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
-              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
           template <class /*Would be IsFixedIndexBasedStorage but gcc doesn't like the constraints
                              here. clang accepts it */
                     ,
@@ -115,7 +115,7 @@ private:
     template <IteratorDirection DIRECTION>
     using Iterator = BidirectionalIterator<ReferenceProvider,
                                            ReferenceProvider,
-                                           IteratorConstness::CONSTANT_ITERATOR(),
+                                           IteratorConstness::CONSTANT_ITERATOR,
                                            DIRECTION>;
 
     // The tree returns NULL_INDEX when an index is not available.
@@ -128,9 +128,9 @@ private:
     }
 
 public:
-    using const_iterator = Iterator<IteratorDirection::FORWARD()>;
+    using const_iterator = Iterator<IteratorDirection::FORWARD>;
     using iterator = const_iterator;
-    using const_reverse_iterator = Iterator<IteratorDirection::REVERSE()>;
+    using const_reverse_iterator = Iterator<IteratorDirection::REVERSE>;
     using reverse_iterator = const_reverse_iterator;
     using size_type = typename Tree::size_type;
     using difference_type = typename Tree::difference_type;
@@ -460,7 +460,7 @@ constexpr typename FixedSet<K, MAXIMUM_SIZE, Compare, COMPACTNESS, StorageTempla
 template <typename K,
           typename Compare = std::less<K>,
           fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
-              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
           template <typename, std::size_t> typename StorageTemplate = FixedIndexBasedPoolStorage,
           fixed_set_customize::FixedSetChecking<K> CheckingType,
           std::size_t MAXIMUM_SIZE,
@@ -485,7 +485,7 @@ template <typename K,
 template <typename K,
           typename Compare = std::less<K>,
           fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
-              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
           template <typename, std::size_t> typename StorageTemplate = FixedIndexBasedPoolStorage,
           std::size_t MAXIMUM_SIZE>
 [[nodiscard]] constexpr auto make_fixed_set(const K (&list)[MAXIMUM_SIZE],

--- a/include/fixed_containers/fixed_vector.hpp
+++ b/include/fixed_containers/fixed_vector.hpp
@@ -180,8 +180,8 @@ public:
     using const_pointer = const T*;
     using reference = T&;
     using const_reference = const T&;
-    using const_iterator = IteratorImpl<IteratorConstness::CONSTANT_ITERATOR()>;
-    using iterator = IteratorImpl<IteratorConstness::MUTABLE_ITERATOR()>;
+    using const_iterator = IteratorImpl<IteratorConstness::CONSTANT_ITERATOR>;
+    using iterator = IteratorImpl<IteratorConstness::MUTABLE_ITERATOR>;
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 

--- a/include/fixed_containers/iterator_utils.hpp
+++ b/include/fixed_containers/iterator_utils.hpp
@@ -1,46 +1,23 @@
 #pragma once
 
-#include "fixed_containers/enum_utils.hpp"
+#include <iterator>
+#include <type_traits>
 
 namespace fixed_containers
 {
-namespace detail
-{
+
 // Names are not just "MUTABLE" and "CONSTANT" to avoid collision with macros
-enum class IteratorConstnessBackingEnum : bool
+enum class IteratorConstness : bool
 {
-    MUTABLE_ITERATOR,
-    CONSTANT_ITERATOR,
-};
-}  // namespace detail
-
-class IteratorConstness
-  : public rich_enums::SkeletalRichEnum<IteratorConstness, detail::IteratorConstnessBackingEnum>
-{
-    friend SkeletalRichEnum::ValuesFriend;
-    using SkeletalRichEnum::SkeletalRichEnum;
-
-public:
-    static constexpr const std::array<IteratorConstness, count()>& values();
-
-    FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(IteratorConstness, MUTABLE_ITERATOR)
-    FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(IteratorConstness, CONSTANT_ITERATOR)
+    MUTABLE_ITERATOR = false,
+    CONSTANT_ITERATOR = true,
 };
 
-constexpr const std::array<IteratorConstness, IteratorConstness::count()>&
-IteratorConstness::values()
+enum class IteratorDirection : bool
 {
-    return rich_enums::SkeletalRichEnumValues<IteratorConstness>::VALUES;
-}
-
-namespace detail
-{
-enum class IteratorDirectionBackingEnum : bool
-{
-    FORWARD,
-    REVERSE,
+    FORWARD = false,
+    REVERSE = true,
 };
-}  // namespace detail
 
 // Using std::reverse_iterator fails to compile with the error message below.
 // Only applies to maps, because they leverage operator->
@@ -86,24 +63,6 @@ declared here _S_to_pointer(_Tp __t)
 // Native support is a bit faster than std::reverse_iterator as the latter does
 // a copy + decrement on every dereference, whereas a non-wrapper doesn't need to do that.
 // clang-format off
-class IteratorDirection
-  : public rich_enums::SkeletalRichEnum<IteratorDirection, detail::IteratorDirectionBackingEnum>
-{
-    friend SkeletalRichEnum::ValuesFriend;
-    using SkeletalRichEnum::SkeletalRichEnum;
-
-public:
-    static constexpr const std::array<IteratorDirection, count()>& values();
-
-    FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(IteratorDirection, FORWARD)
-    FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(IteratorDirection, REVERSE)
-};
-
-constexpr const std::array<IteratorDirection, IteratorDirection::count()>&
-IteratorDirection::values()
-{
-    return rich_enums::SkeletalRichEnumValues<IteratorDirection>::VALUES;
-}
 
 // msvc's array iterator is a class, but gcc's and clang's is a raw pointer.
 // Normally, std::iterator_traits handles this, but for `iterator_concept`

--- a/include/fixed_containers/random_access_iterator_transformer.hpp
+++ b/include/fixed_containers/random_access_iterator_transformer.hpp
@@ -16,37 +16,32 @@ template <class ConstIterator,
           IteratorConstness CONSTNESS>
 class RandomAccessIteratorTransformer
 {
-    // msvc WORKAROUND: "Error C2891 'CONSTNESS' : cannot take the address of a template parameter"
-    // Explanation:
-    // "You can't take the address of a template parameter unless it is an lvalue. Type parameters
-    // are not lvalues because they have no address" To work around that, force l-values.
-    static constexpr IteratorConstness CONSTNESS_LVALUE = CONSTNESS;
-    static constexpr IteratorConstness NEGATED_CONSTNESS_LVALUE = !CONSTNESS;
+    static constexpr IteratorConstness NEGATED_CONSTNESS = IteratorConstness(!bool(CONSTNESS));
 
     using Self = RandomAccessIteratorTransformer<ConstIterator,
                                                  MutableIterator,
                                                  ConstReferenceUnaryFunction,
                                                  MutableReferenceUnaryFunction,
-                                                 CONSTNESS_LVALUE>;
+                                                 CONSTNESS>;
 
     // Sibling has the same parameters, but different const-ness
     using Sibling = RandomAccessIteratorTransformer<ConstIterator,
                                                     MutableIterator,
                                                     ConstReferenceUnaryFunction,
                                                     MutableReferenceUnaryFunction,
-                                                    NEGATED_CONSTNESS_LVALUE>;
+                                                    NEGATED_CONSTNESS>;
 
     // Give Sibling access to private members
     friend class RandomAccessIteratorTransformer<ConstIterator,
                                                  MutableIterator,
                                                  ConstReferenceUnaryFunction,
                                                  MutableReferenceUnaryFunction,
-                                                 NEGATED_CONSTNESS_LVALUE>;
+                                                 NEGATED_CONSTNESS>;
 
-    using IteratorType = std::conditional_t<CONSTNESS_LVALUE == IteratorConstness::CONSTANT_ITERATOR(),
+    using IteratorType = std::conditional_t<CONSTNESS == IteratorConstness::CONSTANT_ITERATOR,
                                             ConstIterator,
                                             MutableIterator>;
-    using UnaryFunction = std::conditional_t<CONSTNESS_LVALUE == IteratorConstness::CONSTANT_ITERATOR(),
+    using UnaryFunction = std::conditional_t<CONSTNESS == IteratorConstness::CONSTANT_ITERATOR,
                                              ConstReferenceUnaryFunction,
                                              MutableReferenceUnaryFunction>;
 
@@ -84,7 +79,7 @@ public:
 
     // Mutable iterator needs to be convertible to const iterator
     constexpr RandomAccessIteratorTransformer(const Sibling& other) noexcept
-        requires(CONSTNESS == IteratorConstness::CONSTANT_ITERATOR())
+        requires(CONSTNESS == IteratorConstness::CONSTANT_ITERATOR)
       : iterator_(other.iterator_)
       , unary_function_(other.unary_function_)
     {

--- a/test/fixed_map_perf_test.cpp
+++ b/test/fixed_map_perf_test.cpp
@@ -14,7 +14,7 @@ using CompactPoolFixedMap =
              V,
              MAXIMUM_SIZE,
              std::less<int>,
-             fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+             fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
              FixedIndexBasedPoolStorage>;
 static_assert(std::is_same_v<FixedMap<int, V, CAP>, CompactPoolFixedMap<int, V, CAP>>);
 
@@ -24,7 +24,7 @@ using CompactContiguousFixedMap =
              V,
              MAXIMUM_SIZE,
              std::less<int>,
-             fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+             fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
              FixedIndexBasedContiguousStorage>;
 
 template <class K, class V, std::size_t MAXIMUM_SIZE>
@@ -33,7 +33,7 @@ using DedicatedColorBitPoolFixedMap =
              V,
              MAXIMUM_SIZE,
              std::less<int>,
-             fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::DEDICATED_COLOR(),
+             fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::DEDICATED_COLOR,
              FixedIndexBasedContiguousStorage>;
 
 template <class K, class V, std::size_t MAXIMUM_SIZE>
@@ -42,7 +42,7 @@ using DedicatedColorBitContiguousFixedMap =
              V,
              MAXIMUM_SIZE,
              std::less<int>,
-             fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::DEDICATED_COLOR(),
+             fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::DEDICATED_COLOR,
              FixedIndexBasedContiguousStorage>;
 
 // The reference boost-based fixed_map (with an array-backed pool-allocator) was at 51000

--- a/test/fixed_red_black_tree_test.cpp
+++ b/test/fixed_red_black_tree_test.cpp
@@ -36,7 +36,7 @@ static_assert(
 using Storage_1 = FixedRedBlackTreeStorage<int,
                                            double,
                                            10,
-                                           RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR(),
+                                           RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
                                            FixedIndexBasedPoolStorage>;
 static_assert(IsFixedRedBlackTreeStorage<Storage_1>);
 static_assert(IsStructuralType<Storage_1>);

--- a/test/fixed_red_black_tree_view_test.cpp
+++ b/test/fixed_red_black_tree_view_test.cpp
@@ -21,7 +21,7 @@ static_assert(std::ranges::forward_range<FixedRedBlackTreeRawView>);
 TEST(FixedRedBlackTreeView, ViewOfPoolStorage)
 {
     constexpr auto COMPACTNESS =
-        fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::DEDICATED_COLOR();
+        fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::DEDICATED_COLOR;
     using FixedSetType = FixedSet<int, 10, std::less<int>, COMPACTNESS, FixedIndexBasedPoolStorage>;
 
     FixedSetType s1{1, 2, 3, 4};
@@ -66,7 +66,7 @@ TEST(FixedRedBlackTreeView, ViewWithStructValue)
     };
 
     constexpr auto COMPACTNESS =
-        fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::DEDICATED_COLOR();
+        fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::DEDICATED_COLOR;
     using FixedSetType = FixedSet<A, 10, std::less<A>, COMPACTNESS, FixedIndexBasedPoolStorage>;
 
     FixedSetType s1{A(1), A(2), A(3)};
@@ -94,7 +94,7 @@ TEST(FixedRedBlackTreeView, ViewWithStructValue)
 TEST(FixedRedBlackTreeView, ViewOfContiguousStorage)
 {
     constexpr auto COMPACTNESS =
-        fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR();
+        fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR;
     using FixedSetType =
         FixedSet<int, 10, std::less<int>, COMPACTNESS, FixedIndexBasedContiguousStorage>;
 
@@ -123,7 +123,7 @@ TEST(FixedRedBlackTreeView, ViewOfContiguousStorage)
 TEST(FixedRedBlackTreeView, PreservedOrdering)
 {
     constexpr auto COMPACTNESS =
-        fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR();
+        fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR;
     using FixedSetType = FixedSet<int, 10, std::less<int>, COMPACTNESS, FixedIndexBasedPoolStorage>;
 
     FixedSetType s1{4, 1, 2, 6, 3, 5};
@@ -152,7 +152,7 @@ TEST(FixedRedBlackTreeView, PreservedOrdering)
 TEST(FixedRedBlackTreeView, SizeCalculation)
 {
     constexpr auto COMPACTNESS =
-        fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR();
+        fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR;
     using FixedSetType = FixedSet<int, 10, std::less<int>, COMPACTNESS, FixedIndexBasedPoolStorage>;
 
     // Test empty set.

--- a/test/index_range_predicate_iterator_test.cpp
+++ b/test/index_range_predicate_iterator_test.cpp
@@ -31,8 +31,8 @@ TEST(IndexRangeIterator, Forward_StartingConditions)
 {
     using ItType = IndexRangeIterator<IdentityIndexProvider,
                                       IdentityIndexProvider,
-                                      IteratorConstness::CONSTANT_ITERATOR(),
-                                      IteratorDirection::FORWARD()>;
+                                      IteratorConstness::CONSTANT_ITERATOR,
+                                      IteratorDirection::FORWARD>;
     {
         constexpr ItType it{{}, {}, 0, 3};
         static_assert(0 == std::integral_constant<std::size_t, *it>{});
@@ -75,8 +75,8 @@ TEST(IndexRangePredicateIterator, Forward_StartingConditions)
     using ItType = IndexRangePredicateIterator<EvenValuesOnly,
                                                IdentityIndexProvider,
                                                IdentityIndexProvider,
-                                               IteratorConstness::CONSTANT_ITERATOR(),
-                                               IteratorDirection::FORWARD()>;
+                                               IteratorConstness::CONSTANT_ITERATOR,
+                                               IteratorDirection::FORWARD>;
     {
         constexpr ItType it{{}, {}, 0, 3};
         static_assert(0 == std::integral_constant<std::size_t, *it>{});
@@ -120,8 +120,8 @@ TEST(IndexRangeIterator, Forward_EmptyIterator)
     using ItType = IndexRangePredicateIterator<AlwaysFalsePredicate,
                                                IdentityIndexProvider,
                                                IdentityIndexProvider,
-                                               IteratorConstness::CONSTANT_ITERATOR(),
-                                               IteratorDirection::FORWARD()>;
+                                               IteratorConstness::CONSTANT_ITERATOR,
+                                               IteratorDirection::FORWARD>;
     {
         constexpr ItType it{{}, {}, 0, 3};
         static_assert(0 == std::integral_constant<std::size_t, *it>{});
@@ -137,8 +137,8 @@ TEST(IndexRangeIterator, Reverse_EmptyIterator)
     using ItType = IndexRangePredicateIterator<AlwaysFalsePredicate,
                                                IdentityIndexProvider,
                                                IdentityIndexProvider,
-                                               IteratorConstness::CONSTANT_ITERATOR(),
-                                               IteratorDirection::REVERSE()>;
+                                               IteratorConstness::CONSTANT_ITERATOR,
+                                               IteratorDirection::REVERSE>;
     {
         constexpr ItType it{{}, {}, 3, 3};
         static_assert(2 == std::integral_constant<std::size_t, *it>{});
@@ -153,8 +153,8 @@ TEST(IndexRangeIterator, Reverse_StartingConditions)
 {
     using ItType = IndexRangeIterator<IdentityIndexProvider,
                                       IdentityIndexProvider,
-                                      IteratorConstness::CONSTANT_ITERATOR(),
-                                      IteratorDirection::REVERSE()>;
+                                      IteratorConstness::CONSTANT_ITERATOR,
+                                      IteratorDirection::REVERSE>;
     {
         constexpr ItType it{{}, {}, 3, 3};
         static_assert(2 == std::integral_constant<std::size_t, *it>{});
@@ -179,8 +179,8 @@ TEST(IndexRangePredicateIterator, Reverse_StartingConditions)
     using ItType = IndexRangePredicateIterator<EvenValuesOnly,
                                                IdentityIndexProvider,
                                                IdentityIndexProvider,
-                                               IteratorConstness::CONSTANT_ITERATOR(),
-                                               IteratorDirection::REVERSE()>;
+                                               IteratorConstness::CONSTANT_ITERATOR,
+                                               IteratorDirection::REVERSE>;
     {
         constexpr ItType it{{}, {}, 3, 3};
         static_assert(2 == std::integral_constant<std::size_t, *it>{});
@@ -204,8 +204,8 @@ TEST(IndexRangeIterator, ForwardIncrement)
 {
     using ItType = IndexRangeIterator<IdentityIndexProvider,
                                       IdentityIndexProvider,
-                                      IteratorConstness::CONSTANT_ITERATOR(),
-                                      IteratorDirection::FORWARD()>;
+                                      IteratorConstness::CONSTANT_ITERATOR,
+                                      IteratorDirection::FORWARD>;
     {
         constexpr std::size_t DISTANCE = std::distance(ItType{{}, {}, 0, 3}, ItType{{}, {}, 3, 3});
         static_assert(3 == std::integral_constant<std::size_t, DISTANCE>{});
@@ -249,8 +249,8 @@ TEST(IndexRangeIterator, ForwardDecrement)
 {
     using ItType = IndexRangeIterator<IdentityIndexProvider,
                                       IdentityIndexProvider,
-                                      IteratorConstness::CONSTANT_ITERATOR(),
-                                      IteratorDirection::FORWARD()>;
+                                      IteratorConstness::CONSTANT_ITERATOR,
+                                      IteratorDirection::FORWARD>;
     {
         constexpr std::size_t DISTANCE = std::distance(ItType{{}, {}, 0, 3}, ItType{{}, {}, 3, 3});
         static_assert(3 == std::integral_constant<std::size_t, DISTANCE>{});
@@ -298,8 +298,8 @@ TEST(IndexRangeIterator, ReverseIncrement)
 {
     using ItType = IndexRangeIterator<IdentityIndexProvider,
                                       IdentityIndexProvider,
-                                      IteratorConstness::CONSTANT_ITERATOR(),
-                                      IteratorDirection::REVERSE()>;
+                                      IteratorConstness::CONSTANT_ITERATOR,
+                                      IteratorDirection::REVERSE>;
     {
         constexpr std::size_t DISTANCE = std::distance(ItType{{}, {}, 3, 3}, ItType{{}, {}, 0, 3});
 
@@ -344,8 +344,8 @@ TEST(IndexRangeIterator, ReverseDecrement)
 {
     using ItType = IndexRangeIterator<IdentityIndexProvider,
                                       IdentityIndexProvider,
-                                      IteratorConstness::CONSTANT_ITERATOR(),
-                                      IteratorDirection::REVERSE()>;
+                                      IteratorConstness::CONSTANT_ITERATOR,
+                                      IteratorDirection::REVERSE>;
     {
         constexpr std::size_t DISTANCE = std::distance(ItType{{}, {}, 3, 3}, ItType{{}, {}, 0, 3});
         static_assert(3 == std::integral_constant<std::size_t, DISTANCE>{});


### PR DESCRIPTION
Representing forward/backward, const/mutable, and red/black doesn't require magic enum machinery. This also removes the need for the repeated "msvc WORKAROUND," as far as I can tell (but please check me on that).