### PR TITLE
Some tweaks to RandomAccessIteratorTransformer

### DIFF
--- a/include/fixed_containers/fixed_red_black_tree_view.hpp
+++ b/include/fixed_containers/fixed_red_black_tree_view.hpp
@@ -50,7 +50,6 @@ public:
         using reference = value_type&;
         using const_reference = const value_type&;
         using iterator_category = std::forward_iterator_tag;
-        using iterator_concept = std::forward_iterator_tag;
 
         Iterator(const std::byte* ptr,
                  std::size_t elem_size_bytes,

--- a/include/fixed_containers/iterator_utils.hpp
+++ b/include/fixed_containers/iterator_utils.hpp
@@ -64,26 +64,4 @@ declared here _S_to_pointer(_Tp __t)
 // a copy + decrement on every dereference, whereas a non-wrapper doesn't need to do that.
 // clang-format off
 
-// msvc's array iterator is a class, but gcc's and clang's is a raw pointer.
-// Normally, std::iterator_traits handles this, but for `iterator_concept`
-// it might not exist:
-// https://en.cppreference.com/w/cpp/iterator/iterator_traits
-//"User specializations may define the member type iterator_concept
-// to one of iterator category tags, to indicate conformance to the
-// iterator concepts."
-//
-// It is only mandated to be defined for the specialization `std::iterator_traits<T*>`
-//
-// As such, use this helper to work for pointers and classes alike.
-template<class IteratorType>
-struct IteratorConceptHelper
-{
-    using iterator_concept =  typename IteratorType::iterator_concept;
-};
-template<class IteratorType> requires std::is_pointer_v<IteratorType>
-struct IteratorConceptHelper<IteratorType>
-{
-    using iterator_concept = typename std::iterator_traits<IteratorType>::iterator_concept;
-};
-
 }  // namespace fixed_containers

--- a/include/fixed_containers/random_access_iterator_transformer.hpp
+++ b/include/fixed_containers/random_access_iterator_transformer.hpp
@@ -46,19 +46,21 @@ class RandomAccessIteratorTransformer
                                              MutableReferenceUnaryFunction>;
 
 public:
-    using reference = decltype(std::declval<UnaryFunction>()(*std::declval<IteratorType>()));
-    using value_type = std::remove_reference_t<reference>;
-    using pointer = std::add_pointer_t<value_type>;
-    using iterator = Self;
-    using element_type = value_type;  // Needed for contiguous iterators
-    using iterator_category = typename std::iterator_traits<IteratorType>::iterator_category;
-    using iterator_concept = typename IteratorConceptHelper<IteratorType>::iterator_concept;
+    static_assert(std::random_access_iterator<ConstIterator>);
+    static_assert(std::random_access_iterator<MutableIterator>);
 
-    static_assert(std::same_as<iterator_category, std::random_access_iterator_tag> ||
-                  std::same_as<iterator_category, std::contiguous_iterator_tag>);
-    static_assert(std::same_as<iterator_concept, std::random_access_iterator_tag> ||
-                  std::same_as<iterator_concept, std::contiguous_iterator_tag>);
+    using reference = decltype(std::declval<UnaryFunction>()(*std::declval<IteratorType>()));
+    using value_type = std::remove_cvref_t<reference>;
+    using pointer = std::add_pointer_t<reference>;
     using difference_type = typename std::iterator_traits<IteratorType>::difference_type;
+    using iterator_category = std::conditional_t<
+        std::contiguous_iterator<IteratorType>,
+        std::contiguous_iterator_tag, std::random_access_iterator_tag
+    >;
+    using element_type = std::conditional_t<
+        std::contiguous_iterator<IteratorType>,
+        std::remove_reference_t<reference>, void
+    >;
 
 private:
     IteratorType iterator_;

--- a/include/fixed_containers/random_access_iterator_transformer.hpp
+++ b/include/fixed_containers/random_access_iterator_transformer.hpp
@@ -131,6 +131,11 @@ public:
         return Self(std::next(iterator_, off), unary_function_);
     }
 
+    friend constexpr Self operator+(difference_type off, const Self& other)
+    {
+        return Self(std::next(other.iterator_, off), other.unary_function_);
+    }
+
     constexpr Self& operator-=(difference_type off)
     {
         std::advance(iterator_, -off);
@@ -152,38 +157,15 @@ public:
         return this->iterator_ - other.iterator_;
     }
 
-    constexpr bool operator==(const Self& other) const noexcept
-    {
-        return this->iterator_ == other.iterator_;
-    }
-
     constexpr std::strong_ordering operator<=>(const Self& other) const
     {
         return this->iterator_ <=> other.iterator_;
     }
 
-    constexpr bool operator==(const Sibling& other) const noexcept
+    constexpr bool operator==(const Self& other) const noexcept
     {
         return this->iterator_ == other.iterator_;
     }
-
-    constexpr std::strong_ordering operator<=>(const Sibling& other) const
-    {
-        return this->iterator_ <=> other.iterator_;
-    }
 };
-
-// Random access iterators require that both of these are valid:
-// 1) it + 5
-// 2) 5 + it
-// This function allows the latter.
-template <class CIt, class MIt, class ConstF, class MutF, IteratorConstness CONSTNESS>
-constexpr RandomAccessIteratorTransformer<CIt, MIt, ConstF, MutF, CONSTNESS> operator+(
-    typename RandomAccessIteratorTransformer<CIt, MIt, ConstF, MutF, CONSTNESS>::difference_type
-        off,
-    RandomAccessIteratorTransformer<CIt, MIt, ConstF, MutF, CONSTNESS> i)
-{
-    return i + off;
-}
 
 }  // namespace fixed_containers

--- a/test/fixed_map_test.cpp
+++ b/test/fixed_map_test.cpp
@@ -27,13 +27,27 @@ static_assert(TriviallyCopyAssignable<ES_1>);
 static_assert(TriviallyMoveAssignable<ES_1>);
 static_assert(IsStructuralType<ES_1>);
 
-static_assert(ranges::bidirectional_iterator<ES_1::iterator>);
-static_assert(ranges::bidirectional_iterator<ES_1::const_iterator>);
+static_assert(std::bidirectional_iterator<ES_1::iterator>);
+static_assert(std::bidirectional_iterator<ES_1::const_iterator>);
+static_assert(!std::random_access_iterator<ES_1::iterator>);
+static_assert(!std::random_access_iterator<ES_1::const_iterator>);
 
 static_assert(std::is_trivially_copyable_v<ES_1::const_iterator>);
 static_assert(std::is_trivially_copyable_v<ES_1::iterator>);
 static_assert(std::is_trivially_copyable_v<ES_1::reverse_iterator>);
 static_assert(std::is_trivially_copyable_v<ES_1::const_reverse_iterator>);
+
+static_assert(std::is_same_v<std::iter_value_t<ES_1::iterator>, fixed_containers::PairView<const int, int>>);
+static_assert(std::is_same_v<std::iter_reference_t<ES_1::iterator>, fixed_containers::PairView<const int, int>&>);
+static_assert(std::is_same_v<std::iter_difference_t<ES_1::iterator>, std::ptrdiff_t>);
+static_assert(std::is_same_v<typename std::iterator_traits<ES_1::iterator>::pointer, fixed_containers::PairView<const int, int>*>);
+static_assert(std::is_same_v<typename std::iterator_traits<ES_1::iterator>::iterator_category, std::bidirectional_iterator_tag>);
+
+static_assert(std::is_same_v<std::iter_value_t<ES_1::const_iterator>, fixed_containers::PairView<const int, const int>>);
+static_assert(std::is_same_v<std::iter_reference_t<ES_1::const_iterator>, fixed_containers::PairView<const int, const int> const&>);
+static_assert(std::is_same_v<std::iter_difference_t<ES_1::const_iterator>, std::ptrdiff_t>);
+static_assert(std::is_same_v<typename std::iterator_traits<ES_1::const_iterator>::pointer, fixed_containers::PairView<const int, const int> const*>);
+static_assert(std::is_same_v<typename std::iterator_traits<ES_1::const_iterator>::iterator_category, std::bidirectional_iterator_tag>);
 
 using STD_MAP_INT_INT = std::map<int, int>;
 static_assert(ranges::bidirectional_iterator<STD_MAP_INT_INT::iterator>);

--- a/test/fixed_set_test.cpp
+++ b/test/fixed_set_test.cpp
@@ -25,8 +25,22 @@ static_assert(TriviallyCopyAssignable<ES_1>);
 static_assert(TriviallyMoveAssignable<ES_1>);
 static_assert(IsStructuralType<ES_1>);
 
-static_assert(ranges::bidirectional_iterator<ES_1::iterator>);
-static_assert(ranges::bidirectional_iterator<ES_1::const_iterator>);
+static_assert(std::bidirectional_iterator<ES_1::iterator>);
+static_assert(std::bidirectional_iterator<ES_1::const_iterator>);
+static_assert(!std::random_access_iterator<ES_1::iterator>);
+static_assert(!std::random_access_iterator<ES_1::const_iterator>);
+
+static_assert(std::is_same_v<std::iter_value_t<ES_1::iterator>, int>);
+static_assert(std::is_same_v<std::iter_reference_t<ES_1::iterator>, const int&>);
+static_assert(std::is_same_v<std::iter_difference_t<ES_1::iterator>, std::ptrdiff_t>);
+static_assert(std::is_same_v<typename std::iterator_traits<ES_1::iterator>::pointer, const int*>);
+static_assert(std::is_same_v<typename std::iterator_traits<ES_1::iterator>::iterator_category, std::bidirectional_iterator_tag>);
+
+static_assert(std::is_same_v<std::iter_value_t<ES_1::const_iterator>, int>);
+static_assert(std::is_same_v<std::iter_reference_t<ES_1::const_iterator>, const int&>);
+static_assert(std::is_same_v<std::iter_difference_t<ES_1::const_iterator>, std::ptrdiff_t>);
+static_assert(std::is_same_v<typename std::iterator_traits<ES_1::const_iterator>::pointer, const int*>);
+static_assert(std::is_same_v<typename std::iterator_traits<ES_1::const_iterator>::iterator_category, std::bidirectional_iterator_tag>);
 
 }  // namespace
 

--- a/test/fixed_vector_test.cpp
+++ b/test/fixed_vector_test.cpp
@@ -38,19 +38,19 @@ static_assert(std::is_same_v<std::iter_value_t<VecType::iterator>, int>);
 static_assert(std::is_same_v<std::iter_reference_t<VecType::iterator>, int&>);
 static_assert(std::is_same_v<std::iter_difference_t<VecType::iterator>, std::ptrdiff_t>);
 static_assert(std::is_same_v<typename std::iterator_traits<VecType::iterator>::pointer, int*>);
-static_assert(std::is_same_v<typename std::iterator_traits<VecType::iterator>::iterator_category, std::random_access_iterator_tag>);
+static_assert(std::is_same_v<typename std::iterator_traits<VecType::iterator>::iterator_category, std::contiguous_iterator_tag>);
 static_assert(std::is_same_v<typename std::pointer_traits<VecType::iterator>::element_type, int>);
 
 static_assert(std::is_same_v<std::iter_value_t<VecType::const_iterator>, int>);
 static_assert(std::is_same_v<std::iter_reference_t<VecType::const_iterator>, const int&>);
 static_assert(std::is_same_v<std::iter_difference_t<VecType::const_iterator>, std::ptrdiff_t>);
 static_assert(std::is_same_v<typename std::iterator_traits<VecType::const_iterator>::pointer, const int*>);
-static_assert(std::is_same_v<typename std::iterator_traits<VecType::const_iterator>::iterator_category, std::random_access_iterator_tag>);
+static_assert(std::is_same_v<typename std::iterator_traits<VecType::const_iterator>::iterator_category, std::contiguous_iterator_tag>);
 static_assert(std::is_same_v<typename std::pointer_traits<VecType::const_iterator>::element_type, const int>);
 
 using ConstVecType = const VecType;
 static_assert(std::is_same_v<int, typename ConstVecType::iterator::value_type>);
-static_assert(std::is_same_v<const int, typename ConstVecType::const_iterator::value_type>); // BUG!
+static_assert(std::is_same_v<int, typename ConstVecType::const_iterator::value_type>);
 }  // namespace trivially_copyable_vector
 
 namespace trivially_copyable_but_not_copyable_or_moveable_vector
@@ -92,14 +92,14 @@ static_assert(std::is_same_v<std::iter_value_t<VecType::iterator>, T>);
 static_assert(std::is_same_v<std::iter_reference_t<VecType::iterator>, T&>);
 static_assert(std::is_same_v<std::iter_difference_t<VecType::iterator>, std::ptrdiff_t>);
 static_assert(std::is_same_v<typename std::iterator_traits<VecType::iterator>::pointer, T*>);
-static_assert(std::is_same_v<typename std::iterator_traits<VecType::iterator>::iterator_category, std::random_access_iterator_tag>);
+static_assert(std::is_same_v<typename std::iterator_traits<VecType::iterator>::iterator_category, std::contiguous_iterator_tag>);
 static_assert(std::is_same_v<typename std::pointer_traits<VecType::iterator>::element_type, T>);
 
 static_assert(std::is_same_v<std::iter_value_t<VecType::const_iterator>, T>);
 static_assert(std::is_same_v<std::iter_reference_t<VecType::const_iterator>, const T&>);
 static_assert(std::is_same_v<std::iter_difference_t<VecType::const_iterator>, std::ptrdiff_t>);
 static_assert(std::is_same_v<typename std::iterator_traits<VecType::const_iterator>::pointer, const T*>);
-static_assert(std::is_same_v<typename std::iterator_traits<VecType::const_iterator>::iterator_category, std::random_access_iterator_tag>);
+static_assert(std::is_same_v<typename std::iterator_traits<VecType::const_iterator>::iterator_category, std::contiguous_iterator_tag>);
 static_assert(std::is_same_v<typename std::pointer_traits<VecType::const_iterator>::element_type, const T>);
 }
 

--- a/test/fixed_vector_test.cpp
+++ b/test/fixed_vector_test.cpp
@@ -48,6 +48,9 @@ static_assert(std::is_same_v<typename std::iterator_traits<VecType::const_iterat
 static_assert(std::is_same_v<typename std::iterator_traits<VecType::const_iterator>::iterator_category, std::random_access_iterator_tag>);
 static_assert(std::is_same_v<typename std::pointer_traits<VecType::const_iterator>::element_type, const int>);
 
+using ConstVecType = const VecType;
+static_assert(std::is_same_v<int, typename ConstVecType::iterator::value_type>);
+static_assert(std::is_same_v<const int, typename ConstVecType::const_iterator::value_type>); // BUG!
 }  // namespace trivially_copyable_vector
 
 namespace trivially_copyable_but_not_copyable_or_moveable_vector


### PR DESCRIPTION
This is three commits: new tests (without changing behavior), better operators (without _observably_ changing behavior, and unrelated to the new tests), and then an ambitious change to the C++20 iterator-concept machinery (which does change behavior, reflected in the new tests). Each one could be taken upstream independently from any of the others, if you like.