### PR TITLE
[FixedMap/EnumMap] Fix dangling references by changing iter return type

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -32,6 +32,9 @@ build:clang --copt -Wno-weak-template-vtables
 #
 build:clang --copt -Wno-global-constructors
 build --copt -Wno-padded
+# Prevents iterators from returning non-references. See also:
+# https://quuxplusone.github.io/blog/2020/08/26/wrange-loop-analysis/
+build:clang --copt -Wno-range-loop-bind-reference
 # due to gtest
 build:clang --copt -Wno-exit-time-destructors
 build:clang --copt -Wno-used-but-marked-unused

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,7 @@ cc_library(
     hdrs = ["include/fixed_containers/bidirectional_iterator.hpp"],
     includes = ["include"],
     deps = [
+        ":arrow_proxy",
         ":iterator_utils",
     ],
     copts = ["-std=c++20"],
@@ -201,7 +202,8 @@ cc_library(
     hdrs = ["include/fixed_containers/index_range_predicate_iterator.hpp"],
     includes = ["include"],
     deps = [
-        ":iterator_utils"
+        ":arrow_proxy",
+        ":iterator_utils",
     ],
     copts = ["-std=c++20"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,6 +5,13 @@ exports_files(["LICENSE"])
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
+    name = "arrow_proxy",
+    hdrs = ["include/fixed_containers/arrow_proxy.hpp"],
+    includes = ["include"],
+    copts = ["-std=c++20"],
+)
+
+cc_library(
     name = "bidirectional_iterator",
     hdrs = ["include/fixed_containers/bidirectional_iterator.hpp"],
     includes = ["include"],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,10 @@ if(${USING_CLANG})
         #
         -Wno-global-constructors
 
+        # Prevents iterators from returning non-references. See also:
+        # https://quuxplusone.github.io/blog/2020/08/26/wrange-loop-analysis/
+        -Wno-range-loop-bind-reference
+
         # due to gtest
         -Wno-covered-switch-default # v1.11.0 fails (needs new release). bazel points to a newer commit with the fix.
         -Wno-exit-time-destructors

--- a/include/fixed_containers/arrow_proxy.hpp
+++ b/include/fixed_containers/arrow_proxy.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <memory>
+
+namespace fixed_containers
+{
+// https://quuxplusone.github.io/blog/2019/02/06/arrow-proxy/
+template <class Reference>
+struct ArrowProxy
+{
+    constexpr Reference* operator->() { return std::addressof(data_); }
+
+    Reference data_;
+};
+}  // namespace fixed_containers

--- a/include/fixed_containers/bidirectional_iterator.hpp
+++ b/include/fixed_containers/bidirectional_iterator.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "fixed_containers/arrow_proxy.hpp"
 #include "fixed_containers/iterator_utils.hpp"
 
 #include <cstddef>
@@ -45,10 +46,14 @@ class BidirectionalIterator
                                                  ConstReferenceProvider,
                                                  MutableReferenceProvider>;
 
+    using ReturnedType = decltype(std::declval<ReferenceProvider>().get());
+    static constexpr bool SAFE_LIFETIME = std::is_reference_v<ReturnedType>;
+
 public:
-    using reference = decltype(std::declval<ReferenceProvider>().get());
+    using reference = ReturnedType;
     using value_type = std::remove_cvref_t<reference>;
-    using pointer = std::add_pointer_t<reference>;
+    using pointer =
+        std::conditional_t<SAFE_LIFETIME, std::add_pointer_t<reference>, ArrowProxy<reference>>;
     using iterator = BidirectionalIterator;
     using iterator_category = std::bidirectional_iterator_tag;
     using difference_type = std::ptrdiff_t;
@@ -80,7 +85,17 @@ public:
 
     constexpr reference operator*() const noexcept { return reference_provider_.get(); }
 
-    constexpr pointer operator->() const noexcept { return &reference_provider_.get(); }
+    constexpr pointer operator->() const noexcept
+    {
+        if constexpr (SAFE_LIFETIME)
+        {
+            return &reference_provider_.get();
+        }
+        else
+        {
+            return {reference_provider_.get()};
+        }
+    }
 
     constexpr BidirectionalIterator& operator++() noexcept
     {

--- a/include/fixed_containers/pair_view.hpp
+++ b/include/fixed_containers/pair_view.hpp
@@ -48,8 +48,12 @@ public:
     // (std::pair<const K, V>), so PairView's operators are deleted to match that behavior. This
     // will cause algorithms like std::remove to fail to compile for fixed_container maps as it does
     // for std::map. See https://en.cppreference.com/w/cpp/algorithm/remove#Notes for more info.
-    constexpr PairView& operator=(const PairView&) requires ALLOW_PUBLIC_ASSIGNMENT = default;
-    constexpr PairView& operator=(PairView&&) noexcept requires ALLOW_PUBLIC_ASSIGNMENT = default;
+    constexpr PairView& operator=(const PairView&)
+        requires ALLOW_PUBLIC_ASSIGNMENT
+    = default;
+    constexpr PairView& operator=(PairView&&) noexcept
+        requires ALLOW_PUBLIC_ASSIGNMENT
+    = default;
 
     constexpr PairView(const PairView&) = default;
     constexpr PairView(PairView&&) noexcept = default;
@@ -149,21 +153,21 @@ template <std::size_t N, class Tp1, class Tp2>
 [[nodiscard]] constexpr auto get(fixed_containers::PairView<Tp1, Tp2>&& in) noexcept ->
     typename tuple_element<N, fixed_containers::PairView<Tp1, Tp2>>::type&&
 {
-    return std::forward<Tp1>(std::move(in).template get<N>());
+    return std::move(in).template get<N>();
 }
 
 template <std::size_t N, class Tp1, class Tp2>
 [[nodiscard]] constexpr auto get(const fixed_containers::PairView<Tp1, Tp2>& in) noexcept -> const
-    typename tuple_element<N, fixed_containers::PairView<Tp1, Tp2>>::type&
+    typename tuple_element<N, const fixed_containers::PairView<Tp1, Tp2>>::type&
 {
     return in.template get<N>();
 }
 
 template <std::size_t N, class Tp1, class Tp2>
 [[nodiscard]] constexpr auto get(const fixed_containers::PairView<Tp1, Tp2>&& in) noexcept -> const
-    typename tuple_element<N, fixed_containers::PairView<Tp1, Tp2>>::type&&
+    typename tuple_element<N, const fixed_containers::PairView<Tp1, Tp2>>::type&&
 {
-    return std::forward<const Tp1>(std::move(in).template get<N>());
+    return std::move(in).template get<N>();
 }
 
 }  // namespace std

--- a/test/enum_map_test.cpp
+++ b/test/enum_map_test.cpp
@@ -1095,6 +1095,42 @@ TEST(EnumMap, Iterator_AccessingDefaultConstructedIteratorFails)
     EXPECT_DEATH(it->second()++, "");
 }
 
+static constexpr EnumMap<TestEnum1, int> LIVENESS_TEST_INSTANCE{{TestEnum1::ONE, 100}};
+
+TEST(EnumMap, IteratorDereferenceLiveness)
+{
+    {
+        constexpr auto ref = []() { return *LIVENESS_TEST_INSTANCE.begin(); }();
+        static_assert(ref.first() == TestEnum1::ONE);
+        static_assert(ref.second() == 100);
+    }
+
+    {
+        /*
+        // this test needs ubsan/asan
+        EnumMap<TestEnum1, int> m = {{TestEnum1::ONE, 2}};
+        decltype(m)::reference ref = *m.begin();  // Dangling!!
+        EXPECT_EQ(TestEnum1::ONE, ref.first());
+        EXPECT_EQ(2, ref.second());
+         */
+    } {
+        // this test needs ubsan/asan
+        EnumMap<TestEnum1, int> m = {{TestEnum1::ONE, 2}};
+        auto ref = *m.begin();  // Fine
+        EXPECT_EQ(TestEnum1::ONE, ref.first());
+        EXPECT_EQ(2, ref.second());
+    }
+    {
+        /*
+        // this test needs ubsan/asan
+        EnumMap<TestEnum1, int> m = {{TestEnum1::ONE, 2}};
+        auto& ref = *m.begin();  // Dangling!!
+        EXPECT_EQ(TestEnum1::ONE, ref.first());
+        EXPECT_EQ(2, ref.second());
+         */
+    }
+}
+
 TEST(EnumMap, ReverseIteratorBasic)
 {
     constexpr EnumMap<TestEnum1, int> s1{

--- a/test/fixed_map_test.cpp
+++ b/test/fixed_map_test.cpp
@@ -1012,6 +1012,42 @@ TEST(FixedMap, Iterator_AccessingDefaultConstructedIteratorFails)
     EXPECT_DEATH(it->second()++, "");
 }
 
+static constexpr FixedMap<int, int, 7> LIVENESS_TEST_INSTANCE{{1, 100}};
+
+TEST(FixedMap, IteratorDereferenceLiveness)
+{
+    {
+        constexpr auto ref = []() { return *LIVENESS_TEST_INSTANCE.begin(); }();
+        static_assert(ref.first() == 1);
+        static_assert(ref.second() == 100);
+    }
+
+    {
+        /*
+        // this test needs ubsan/asan
+        FixedMap<int, int, 7> m = {{1, 100}};
+        decltype(m)::reference ref = *m.begin();  // Dangling!!
+        EXPECT_EQ(1, ref.first());
+        EXPECT_EQ(100, ref.second());
+         */
+    } {
+        // this test needs ubsan/asan
+        FixedMap<int, int, 7> m = {{1, 100}};
+        auto ref = *m.begin();  // Fine
+        EXPECT_EQ(1, ref.first());
+        EXPECT_EQ(100, ref.second());
+    }
+    {
+        /*
+        // this test needs ubsan/asan
+        FixedMap<int, int, 7> m = {{1, 100}};
+        auto& ref = *m.begin();  // Dangling!!
+        EXPECT_EQ(1, ref.first());
+        EXPECT_EQ(100, ref.second());
+         */
+    }
+}
+
 TEST(FixedMap, ReverseIteratorBasic)
 {
     constexpr FixedMap<int, int, 10> s1{{1, 10}, {2, 20}, {3, 30}, {4, 40}};

--- a/test/pair_view_test.cpp
+++ b/test/pair_view_test.cpp
@@ -6,16 +6,81 @@
 
 namespace fixed_containers
 {
+
 TEST(PairView, std_get)
 {
     {
-        std::pair<int, int> s;
-        static_cast<void>(std::get<1>(s));
+        int first_value = 5;
+        std::string second_value = "blah";
+        PairView<int, std::string> s{&first_value, &second_value};
+        static_assert(std::is_same_v<int&, decltype(std::get<0>(s))>);
+        static_assert(std::is_same_v<std::string&, decltype(std::get<1>(s))>);
+        EXPECT_EQ(5, std::get<0>(s));
+        EXPECT_EQ("blah", std::get<1>(s));
+
+        PairView<int, std::string>& mutable_ref = s;
+        static_assert(std::is_same_v<int&, decltype(std::get<0>(mutable_ref))>);
+        static_assert(std::is_same_v<std::string&, decltype(std::get<1>(mutable_ref))>);
+        EXPECT_EQ(5, std::get<0>(mutable_ref));
+        EXPECT_EQ("blah", std::get<1>(mutable_ref));
+
+        const PairView<int, std::string>& const_ref = s;
+        static_assert(std::is_same_v<const int&, decltype(std::get<0>(const_ref))>);
+        static_assert(std::is_same_v<const std::string&, decltype(std::get<1>(const_ref))>);
+        EXPECT_EQ(5, std::get<0>(const_ref));
+        EXPECT_EQ("blah", std::get<1>(const_ref));
+
+        // r-value
+        static_assert(std::is_same_v<int&, decltype(std::get<0>(PairView<int, std::string>{s}))>);
+        static_assert(
+            std::is_same_v<std::string&, decltype(std::get<1>(PairView<int, std::string>{s}))>);
+        EXPECT_EQ(5, std::get<0>(PairView<int, std::string>{s}));
+        EXPECT_EQ("blah", std::get<1>(PairView<int, std::string>{s}));
+
+        using CostRvalue = const PairView<int, std::string>&&;
+        static_assert(
+            std::is_same_v<const int&, decltype(std::get<0>(static_cast<CostRvalue>(s)))>);
+        static_assert(
+            std::is_same_v<const std::string&, decltype(std::get<1>(static_cast<CostRvalue>(s)))>);
+        EXPECT_EQ(5, std::get<0>(static_cast<CostRvalue>(s)));
+        EXPECT_EQ("blah", std::get<1>(static_cast<CostRvalue>(s)));
     }
 
     {
-        PairView<int, int> s;
-        static_cast<void>(std::get<1>(s));
+        int first_value = 5;
+        std::string second_value = "blah";
+        std::pair<int&, std::string&> s{first_value, second_value};
+        static_assert(std::is_same_v<int&, decltype(std::get<0>(s))>);
+        static_assert(std::is_same_v<std::string&, decltype(std::get<1>(s))>);
+        EXPECT_EQ(5, std::get<0>(s));
+        EXPECT_EQ("blah", std::get<1>(s));
+
+        std::pair<int&, std::string&> mutable_ref = s;
+        static_assert(std::is_same_v<int&, decltype(std::get<0>(mutable_ref))>);
+        static_assert(std::is_same_v<std::string&, decltype(std::get<1>(mutable_ref))>);
+        EXPECT_EQ(5, std::get<0>(mutable_ref));
+        EXPECT_EQ("blah", std::get<1>(mutable_ref));
+
+        const std::pair<int&, std::string&>& const_ref = s;
+        static_assert(std::is_same_v<int&, decltype(std::get<0>(const_ref))>);
+        static_assert(std::is_same_v<std::string&, decltype(std::get<1>(const_ref))>);
+        EXPECT_EQ(5, std::get<0>(const_ref));
+        EXPECT_EQ("blah", std::get<1>(const_ref));
+
+        // r-value
+        static_assert(
+            std::is_same_v<int&, decltype(std::get<0>(std::pair<int&, std::string&>{s}))>);
+        static_assert(
+            std::is_same_v<std::string&, decltype(std::get<1>(std::pair<int&, std::string&>{s}))>);
+        EXPECT_EQ(5, std::get<0>(std::pair<int&, std::string&>{s}));
+        EXPECT_EQ("blah", std::get<1>(std::pair<int&, std::string&>{s}));
+
+        using CostRvalue = const std::pair<int&, std::string&>&&;
+        static_assert(std::is_same_v<int&, decltype(std::get<0>(static_cast<CostRvalue>(s)))>);
+        static_assert(
+            std::is_same_v<std::string&, decltype(std::get<1>(static_cast<CostRvalue>(s)))>);
+        EXPECT_EQ(5, std::get<0>(static_cast<CostRvalue>(s)));
+        EXPECT_EQ("blah", std::get<1>(static_cast<CostRvalue>(s)));
     }
 }
 


### PR DESCRIPTION
Currently, `FixedMap` and `EnumMap` return a `PairView<const K, const V>&` (notably, a reference in contrast to a value) in order to be able to support the same syntax that `std::map` does when iterating, i.e.:
```cpp
for (auto&& pair : map) {} // a
for (const auto& pair : map) {} // b
for (auto& pair : map) {} // c
```

However, this makes it possible for dangling references to occur.
```cpp
decltype(m)::reference ref = *m.begin(); // Dangling // 1
auto ref = *m.begin();  // Fine // 2
auto& ref = *m.begin();  // Dangling // 3
```
(all 3 are fine for `std::map`).

Problems:
1) Cannot store a `std::pair<const K, V>` because it is not assignable and not trivially copyable, so it is not possible to give a reference to it. Also, for `EnumMap` the key is not even stored, so there is no pair at all. [further explanation](https://github.com/alexkaratarakis/fixed-containers/tree/7ee3622879f35faa41603c22daad56d934eddd83#explanation)
2) To synthesize a reference (as opposed to a value) the iterator is taxed with keeping the storage alive, so if it goes out of scope, then the reference is dangling, which is what happens with 1 and 3. 2 does a copy, so it is safe.

To address the issue, return `PairView<const K, const V>` by value (not a reference). This fixes dangling issues as demo-ed in the [unit tests](https://github.com/teslamotors/fixed-containers/pull/45/commits/1258e02f212df60196c7895f8913e240ee46b89b#diff-a44022add7a53c46e370b40bddb167128a8fcc016977cd08b95193f81fe631d7R1038). This makes it so syntax `c` is an error, and syntax `b` is a warning (which we can disable). Syntax `a` works as always [source](https://quuxplusone.github.io/blog/2018/12/15/autorefref-always-works/).

This also makes it unnecessary to use `PairView`, and allows switching to `std::pair` which removes the `first()/second()` API discrepancy, outlined [here](https://github.com/teslamotors/fixed-containers/tree/7ee3622879f35faa41603c22daad56d934eddd83#api-deviations-compared-to-the-standard-library). This will be done in a subsequent change to `std::pair<const K&, V&>`, which is also the type used by the upcoming (C++23) [`std::flat_map`](https://github.com/Quuxplusone/SG14/blob/master/include/sg14/flat_map.h)

Relevant discussion:
https://github.com/teslamotors/fixed-containers/pull/34
https://github.com/teslamotors/fixed-containers/pull/38