### PR TITLE
Use _GLIBXX_RELEASE instead of __GNUC__ to detect version of libstdc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ else()
 endif()
 if(${USING_CLANG})
     target_compile_options(project_options INTERFACE -ftrivial-auto-var-init=pattern)
+    #target_compile_options(project_options INTERFACE --gcc-install-dir=/usr/bin/../lib/gcc/x86_64-linux-gnu/11)
 endif()
 target_compile_features(project_options INTERFACE cxx_std_${CMAKE_CXX_STANDARD})
 

--- a/include/fixed_containers/enum_map.hpp
+++ b/include/fixed_containers/enum_map.hpp
@@ -288,7 +288,7 @@ public:
         using T1 = typename decltype(Arg0)::first_type;
         using T2 = typename decltype(Arg0)::second_type;
 
-#if defined(__GNUC__) and __GNUC__ < 12 and !defined(__clang__)
+#if defined(_GLIBCXX_RELEASE) and _GLIBCXX_RELEASE < 12
         using PairType = Pair<T1, T2>;
 #else
         using PairType = std::pair<T1, T2>;

--- a/test/enum_map_test.cpp
+++ b/test/enum_map_test.cpp
@@ -279,7 +279,7 @@ TEST(EnumMap, CreateWithAllEntriesWithCompileTimeErrorReporting)
     static_cast<void>(fixed_containers::CompileTimeValuePrinter<fixed_containers::rich_enums::TestEnum1::THREE>{})
     , HAS_MISSING_ENTRIES': Found missing entries.
      */
-#if defined(__GNUC__) and __GNUC__ < 12 and !defined(__clang__)
+#if defined(_GLIBCXX_RELEASE) and _GLIBCXX_RELEASE < 12
     constexpr auto s1 =
         EnumMap<TestEnum1, int>::create_with_all_entries<Pair{TestEnum1::ONE, 42},
                                                          Pair{TestEnum1::TWO, 7},

--- a/test/pair_test.cpp
+++ b/test/pair_test.cpp
@@ -12,7 +12,7 @@ static_assert(NotTriviallyCopyable<std::pair<int, int>>);
 static_assert(TriviallyCopyable<std::pair<int, int>>);
 #endif
 
-#if defined(__GNUC__) and __GNUC__ < 12 and !defined(__clang__)
+#if defined(_GLIBCXX_RELEASE) and _GLIBCXX_RELEASE < 12
 static_assert(IsNotStructuralType<std::pair<int, int>>);
 #else
 static_assert(IsStructuralType<std::pair<int, int>>);


### PR DESCRIPTION
clang defines the __GNUC__,__GNUC_MINOR__, __GNUC_PATCHLEVEL__ macros, but they are hardcoded to version 4.2.1 and do not reflect the real version of libstdc++.

Instead, use _GLIBCXX_RELEASE. This allows proper libstdc++ version detection when compiling with clang (and using gcc libs)