### PR TITLE
Fix FixedVector and EnumMap to work with ADL and CTAD

### DIFF
--- a/include/fixed_containers/enum_map.hpp
+++ b/include/fixed_containers/enum_map.hpp
@@ -957,7 +957,75 @@ template <class K,
           class V,
           enum_map_customize::EnumMapChecking<K> CheckingType =
               enum_map_customize::AbortChecking<K, V>>
-using EnumMap = enum_map_detail::specializations::EnumMap<K, V, CheckingType>;
+class EnumMap : public enum_map_detail::specializations::EnumMap<K, V, CheckingType>
+{
+    using Self = EnumMap<K, V, CheckingType>;
+    using Base = enum_map_detail::specializations::EnumMap<K, V, CheckingType>;
+
+public:
+    using Builder = enum_map_detail::EnumMapBuilder<K, V, Self>;
+
+    template <class Container, class EnumMapType = Self>
+    static constexpr EnumMapType create_with_keys(const Container& sp, const V& value = V())
+    {
+        return Base::template create_with_keys<Container, EnumMapType>(sp, value);
+    }
+
+    template <class CollectionOfPairs, class EnumMapType = Self>
+    static constexpr EnumMapType create_with_all_entries(
+        const CollectionOfPairs& pairs,
+        const std_transition::source_location& loc = std_transition::source_location::current())
+    {
+        return Base::template create_with_all_entries<CollectionOfPairs, EnumMapType>(pairs, loc);
+    }
+
+    template <class EnumMapType = Self>
+    static constexpr EnumMapType create_with_all_entries(
+        std::initializer_list<typename Base::value_type> pairs,
+        const std_transition::source_location& loc = std_transition::source_location::current())
+    {
+        return Base::template create_with_all_entries<EnumMapType>(pairs, loc);
+    }
+
+    template <class EnumMapType, auto COLLECTION_OF_PAIRS>
+        requires(HasValueType<decltype(COLLECTION_OF_PAIRS)>)
+    static consteval auto create_with_all_entries()
+    {
+        return Base::template create_with_all_entries<EnumMapType, COLLECTION_OF_PAIRS>();
+    }
+    template <auto COLLECTION_OF_PAIRS>
+        requires(HasValueType<decltype(COLLECTION_OF_PAIRS)>)
+    static consteval auto create_with_all_entries()
+    {
+        return create_with_all_entries<Self, COLLECTION_OF_PAIRS>();
+    }
+    template <class EnumMapType, auto Arg0, auto... Args>
+        requires(not HasValueType<decltype(Arg0)>)
+    static consteval auto create_with_all_entries()
+    {
+        return Base::template create_with_all_entries<EnumMapType, Arg0, Args...>();
+    }
+    template <auto Arg0, auto... Args>
+        requires(not HasValueType<decltype(Arg0)>)
+    static consteval auto create_with_all_entries()
+    {
+        return create_with_all_entries<Self, Arg0, Args...>();
+    }
+
+    constexpr EnumMap() noexcept
+      : Base()
+    {
+    }
+    template <InputIterator InputIt>
+    constexpr EnumMap(InputIt first, InputIt last)
+      : Base(first, last)
+    {
+    }
+    constexpr EnumMap(std::initializer_list<typename Base::value_type> list) noexcept
+      : Base(list)
+    {
+    }
+};
 
 template <class K, class V, enum_map_customize::EnumMapChecking<K> CheckingType, class Predicate>
 constexpr typename EnumMap<K, V, CheckingType>::size_type erase_if(EnumMap<K, V, CheckingType>& c,

--- a/include/fixed_containers/enum_map.hpp
+++ b/include/fixed_containers/enum_map.hpp
@@ -718,21 +718,6 @@ class EnumMap : public enum_map_detail::EnumMapBase<K, V, CheckingType>
     using Base = enum_map_detail::EnumMapBase<K, V, CheckingType>;
 
 public:
-    using key_type = typename Base::key_type;
-    using mapped_type = typename Base::mapped_type;
-    using value_type = typename Base::value_type;
-    using reference = typename Base::reference;
-    using const_reference = typename Base::const_reference;
-    using pointer = typename Base::pointer;
-    using const_pointer = typename Base::const_pointer;
-    using const_iterator = typename Base::const_iterator;
-    using iterator = typename Base::iterator;
-    using const_reverse_iterator = typename Base::const_reverse_iterator;
-    using reverse_iterator = typename Base::reverse_iterator;
-    using size_type = typename Base::size_type;
-    using difference_type = typename Base::difference_type;
-
-public:
     using Builder = enum_map_detail::EnumMapBuilder<K, V, EnumMap<K, V, CheckingType>>;
 
     template <class Container, class EnumMapType = Self>
@@ -751,7 +736,7 @@ public:
 
     template <class EnumMapType = Self>
     static constexpr EnumMapType create_with_all_entries(
-        std::initializer_list<value_type> pairs,
+        std::initializer_list<typename Base::value_type> pairs,
         const std_transition::source_location& loc = std_transition::source_location::current())
     {
         return Base::template create_with_all_entries<EnumMapType>(pairs, loc);
@@ -792,7 +777,7 @@ public:
       : Base(first, last)
     {
     }
-    constexpr EnumMap(std::initializer_list<value_type> list) noexcept
+    constexpr EnumMap(std::initializer_list<typename Base::value_type> list) noexcept
       : Base(list)
     {
     }
@@ -894,21 +879,6 @@ class EnumMap<K, V, CheckingType> : public enum_map_detail::EnumMapBase<K, V, Ch
     using Base = enum_map_detail::EnumMapBase<K, V, CheckingType>;
 
 public:
-    using key_type = typename Base::key_type;
-    using mapped_type = typename Base::mapped_type;
-    using value_type = typename Base::value_type;
-    using reference = typename Base::reference;
-    using const_reference = typename Base::const_reference;
-    using pointer = typename Base::pointer;
-    using const_pointer = typename Base::const_pointer;
-    using const_iterator = typename Base::const_iterator;
-    using iterator = typename Base::iterator;
-    using const_reverse_iterator = typename Base::const_reverse_iterator;
-    using reverse_iterator = typename Base::reverse_iterator;
-    using size_type = typename Base::size_type;
-    using difference_type = typename Base::difference_type;
-
-public:
     using Builder = enum_map_detail::EnumMapBuilder<K, V, Self>;
 
     template <class Container, class EnumMapType = Self>
@@ -927,7 +897,7 @@ public:
 
     template <class EnumMapType = Self>
     static constexpr EnumMapType create_with_all_entries(
-        std::initializer_list<value_type> pairs,
+        std::initializer_list<typename Base::value_type> pairs,
         const std_transition::source_location& loc = std_transition::source_location::current())
     {
         return Base::template create_with_all_entries<EnumMapType>(pairs, loc);
@@ -967,7 +937,7 @@ public:
       : Base(first, last)
     {
     }
-    constexpr EnumMap(std::initializer_list<value_type> list) noexcept
+    constexpr EnumMap(std::initializer_list<typename Base::value_type> list) noexcept
       : Base(list)
     {
     }

--- a/include/fixed_containers/fixed_vector.hpp
+++ b/include/fixed_containers/fixed_vector.hpp
@@ -1026,8 +1026,47 @@ template <typename T,
           std::size_t MAXIMUM_SIZE,
           fixed_vector_customize::FixedVectorChecking CheckingType =
               fixed_vector_customize::AbortChecking<T, MAXIMUM_SIZE>>
-using FixedVector =
-    fixed_vector_detail::specializations::FixedVector<T, MAXIMUM_SIZE, CheckingType>;
+class FixedVector
+  : public fixed_vector_detail::specializations::FixedVector<T, MAXIMUM_SIZE, CheckingType>
+{
+    using Base = fixed_vector_detail::specializations::FixedVector<T, MAXIMUM_SIZE, CheckingType>;
+
+public:
+    using Builder =
+        fixed_vector_detail::FixedVectorBuilder<T, FixedVector<T, MAXIMUM_SIZE, CheckingType>>;
+
+    constexpr FixedVector() noexcept
+      : Base()
+    {
+    }
+    constexpr FixedVector(std::initializer_list<T> list,
+                          const std_transition::source_location& loc =
+                              std_transition::source_location::current()) noexcept
+      : Base(list, loc)
+    {
+    }
+    constexpr FixedVector(std::size_t count,
+                          const T& value,
+                          const std_transition::source_location& loc =
+                              std_transition::source_location::current()) noexcept
+      : Base(count, value, loc)
+    {
+    }
+    constexpr explicit FixedVector(std::size_t count,
+                                   const std_transition::source_location& loc =
+                                       std_transition::source_location::current()) noexcept
+      : Base(count, loc)
+    {
+    }
+    template <InputIterator InputIt>
+    constexpr FixedVector(InputIt first,
+                          InputIt last,
+                          const std_transition::source_location& loc =
+                              std_transition::source_location::current()) noexcept
+      : Base(first, last, loc)
+    {
+    }
+};
 
 template <typename T, std::size_t MAXIMUM_SIZE, typename CheckingType>
 constexpr typename FixedVector<T, MAXIMUM_SIZE, CheckingType>::size_type is_full(

--- a/test/enum_map_test.cpp
+++ b/test/enum_map_test.cpp
@@ -1378,6 +1378,13 @@ TEST(EnumMap, Ranges)
     EXPECT_EQ(10, first_entry);
 }
 
+TEST(EnumMap, ClassTemplateArgumentDeduction)
+{
+    // Compile-only test
+    EnumMap a = EnumMap<TestEnum1, int>{};
+    (void)a;
+}
+
 TEST(EnumMap, NonDefaultConstructible)
 {
     {
@@ -1812,3 +1819,13 @@ INSTANTIATE_TYPED_TEST_SUITE_P(EnumMap,
                                NameProviderForTypeParameterizedTest);
 
 }  // namespace fixed_containers
+
+namespace another_namespace_unrelated_to_the_fixed_containers_namespace
+{
+TEST(EnumMap, ArgumentDependentLookup)
+{
+    // Compile-only test
+    fixed_containers::EnumMap<fixed_containers::TestEnum1, int> a{};
+    erase_if(a, [](auto&&) { return true; });
+}
+}  // namespace another_namespace_unrelated_to_the_fixed_containers_namespace

--- a/test/enum_set_test.cpp
+++ b/test/enum_set_test.cpp
@@ -633,6 +633,13 @@ TEST(EnumSet, Ranges)
     EXPECT_EQ(TestRichEnum1::C_FOUR(), *f.begin());
 }
 
+TEST(EnumSet, ClassTemplateArgumentDeduction)
+{
+    // Compile-only test
+    EnumSet a = EnumSet<TestEnum1>{};
+    (void)a;
+}
+
 TEST(EnumSet, SetIntersection)
 {
     constexpr EnumSet<TestEnum1> s1 = []()
@@ -678,3 +685,13 @@ TEST(EnumSet, UsageAsTemplateParameter)
 }
 
 }  // namespace fixed_containers
+
+namespace another_namespace_unrelated_to_the_fixed_containers_namespace
+{
+TEST(EnumSet, ArgumentDependentLookup)
+{
+    // Compile-only test
+    fixed_containers::EnumSet<fixed_containers::TestEnum1> a{};
+    erase_if(a, [](fixed_containers::TestEnum1) { return true; });
+}
+}  // namespace another_namespace_unrelated_to_the_fixed_containers_namespace

--- a/test/fixed_map_test.cpp
+++ b/test/fixed_map_test.cpp
@@ -1294,6 +1294,13 @@ TEST(FixedMap, Ranges)
     EXPECT_EQ(10, first_entry);
 }
 
+TEST(FixedMap, ClassTemplateArgumentDeduction)
+{
+    // Compile-only test
+    FixedMap a = FixedMap<int, int, 5>{};
+    (void)a;
+}
+
 TEST(FixedMap, NonDefaultConstructible)
 {
     {
@@ -1732,3 +1739,14 @@ INSTANTIATE_TYPED_TEST_SUITE_P(FixedMap,
                                NameProviderForTypeParameterizedTest);
 
 }  // namespace fixed_containers
+
+namespace another_namespace_unrelated_to_the_fixed_containers_namespace
+{
+TEST(FixedMap, ArgumentDependentLookup)
+{
+    // Compile-only test
+    fixed_containers::FixedMap<int, int, 5> a{};
+    erase_if(a, [](auto&&) { return true; });
+    is_full(a);
+}
+}  // namespace another_namespace_unrelated_to_the_fixed_containers_namespace

--- a/test/fixed_set_test.cpp
+++ b/test/fixed_set_test.cpp
@@ -576,6 +576,13 @@ TEST(FixedSet, Ranges)
     EXPECT_EQ(4, *f.begin());
 }
 
+TEST(FixedSet, ClassTemplateArgumentDeduction)
+{
+    // Compile-only test
+    FixedSet a = FixedSet<int, 5>{};
+    (void)a;
+}
+
 TEST(FixedSet, SetIntersection)
 {
     constexpr FixedSet<int, 10> s1 = []()
@@ -619,3 +626,14 @@ TEST(FixedSet, UsageAsTemplateParameter)
 }
 
 }  // namespace fixed_containers
+
+namespace another_namespace_unrelated_to_the_fixed_containers_namespace
+{
+TEST(FixedSet, ArgumentDependentLookup)
+{
+    // Compile-only test
+    fixed_containers::FixedSet<int, 5> a{};
+    erase_if(a, [](int) { return true; });
+    is_full(a);
+}
+}  // namespace another_namespace_unrelated_to_the_fixed_containers_namespace

--- a/test/fixed_vector_test.cpp
+++ b/test/fixed_vector_test.cpp
@@ -1867,6 +1867,13 @@ TEST(FixedVector, NonTriviallyCopyableMoveAssignment)
     EXPECT_TRUE(are_equal(v2, std::array<MockNonTrivialInt, 2>{1, 2}));
 }
 
+TEST(FixedVector, ClassTemplateArgumentDeduction)
+{
+    // Compile-only test
+    FixedVector a = FixedVector<int, 5>{};
+    (void)a;
+}
+
 namespace
 {
 template <FixedVector<int, 5> /*MY_VEC*/>
@@ -2102,3 +2109,15 @@ INSTANTIATE_TYPED_TEST_SUITE_P(FixedVector,
                                NameProviderForTypeParameterizedTest);
 
 }  // namespace fixed_containers
+
+namespace another_namespace_unrelated_to_the_fixed_containers_namespace
+{
+TEST(FixedVector, ArgumentDependentLookup)
+{
+    // Compile-only test
+    fixed_containers::FixedVector<int, 5> a{};
+    erase(a, 5);
+    erase_if(a, [](int) { return true; });
+    is_full(a);
+}
+}  // namespace another_namespace_unrelated_to_the_fixed_containers_namespace


### PR DESCRIPTION
Aliases don't work here, use a forwarding child class.

https://en.cppreference.com/w/cpp/language/adl
https://en.cppreference.com/w/cpp/language/class_template_argument_deduction