### PR TITLE
Skip finding magic_enum package if the target exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,9 @@ add_library(project_warnings INTERFACE)
 target_compile_options(project_warnings INTERFACE ${DIAGNOSTIC_FLAGS})
 
 
-find_package(magic_enum CONFIG REQUIRED)
+if(NOT TARGET magic_enum)
+    find_package(magic_enum CONFIG REQUIRED)
+endif()
 
 add_library(fixed_containers INTERFACE)
 add_library(fixed_containers::fixed_containers ALIAS fixed_containers)


### PR DESCRIPTION
Make the CMakeLists.txt more friendly if magic_enum is already in the project.