### PR TITLE
[SkeletalRichEnum] Fix ordinal() and value_of(underlying_int)

### DIFF
--- a/include/fixed_containers/enum_utils.hpp
+++ b/include/fixed_containers/enum_utils.hpp
@@ -514,9 +514,6 @@ public:
         return rich_enums_detail::value_of<RichEnumType>(backing_enum);
     }
 
-private:
-    static constexpr std::string_view INVALID_TO_STRING = "INVALID";
-
 protected:
     // Default constructor for supporting sentinel value semantics (e.g. INVALID) without a
     // dedicated enum constant. Does not exclude child-classes from using their own INVALID enum

--- a/include/fixed_containers/enum_utils.hpp
+++ b/include/fixed_containers/enum_utils.hpp
@@ -30,6 +30,14 @@ concept has_member_sizet_ordinal_void_const = requires(T t) {
 };
 
 template <typename T>
+concept has_backing_enum_typename_and_member_backing_enum_void_const = requires(T t) {
+    typename T::BackingEnum;
+    {
+        t.backing_enum()
+    } -> std::same_as<const typename T::BackingEnum&>;
+};
+
+template <typename T>
 concept has_static_sizet_count_void = requires() {
     {
         T::count()
@@ -114,6 +122,7 @@ constexpr bool has_zero_based_and_sorted_contiguous_ordinal()
 template <class T>
 concept is_rich_enum =
     has_static_sizet_count_void<T> && has_static_const_ref_array_values_void<T, T, T::count()> &&
+    has_backing_enum_typename_and_member_backing_enum_void_const<T> &&
     has_member_sizet_ordinal_void_const<T> && has_member_std_string_view_to_string_void_const<T> &&
     has_zero_based_and_sorted_contiguous_ordinal(T::values(), RichEnumOrdinalFunctor<T>{});
 

--- a/include/fixed_containers/enum_utils.hpp
+++ b/include/fixed_containers/enum_utils.hpp
@@ -590,45 +590,15 @@ class SkeletalRichEnum
     using Base = SkeletalRichEnumLite<RichEnumType, BackingEnumType, InfusedDataProviderType>;
 
 public:
-    using BackingEnum = BackingEnumType;
-
-protected:
-    using ValuesFriend = SkeletalRichEnumValues<RichEnumType>;
-    using InfusedDataProvider = InfusedDataProviderType;
-    using InfusedData = typename InfusedDataProvider::DataType;
-
-public:
     static constexpr std::size_t count() { return magic_enum::enum_count<BackingEnumType>(); }
 
 private:
     static constexpr std::string_view INVALID_TO_STRING = "INVALID";
 
 protected:
-    // Default constructor for supporting sentinel value semantics (e.g. INVALID) without a
-    // dedicated enum constant. Does not exclude child-classes from using their own INVALID enum
-    // constant.
-    // Note that child-classes don't have to provide a default constructor.
-    constexpr SkeletalRichEnum() noexcept = default;
-
-    explicit(false) constexpr SkeletalRichEnum(const BackingEnum& backing_enum) noexcept
-        requires(std::is_empty_v<InfusedData>)
-      : Base{backing_enum}
-    {
-    }
-
-    constexpr SkeletalRichEnum(const BackingEnum& backing_enum,
-                               const InfusedData& enum_data) noexcept
-        requires(!std::is_empty_v<InfusedData>)
-      : Base{backing_enum, enum_data}
-    {
-    }
+    using Base::Base;
 
 public:
-    constexpr SkeletalRichEnum(const SkeletalRichEnum&) noexcept = default;
-    constexpr SkeletalRichEnum(SkeletalRichEnum&&) noexcept = default;
-    constexpr SkeletalRichEnum& operator=(const SkeletalRichEnum&) noexcept = default;
-    constexpr SkeletalRichEnum& operator=(SkeletalRichEnum&&) noexcept = default;
-
     [[nodiscard]] constexpr std::string_view to_string() const
     {
         if (this->has_value())
@@ -637,10 +607,6 @@ public:
         }
         return INVALID_TO_STRING;
     }
-
-protected:
-    // Intentionally non-virtual. Polymorphism breaks standard layout.
-    constexpr ~SkeletalRichEnum() noexcept = default;
 };
 
 template <class RichEnumType,
@@ -653,30 +619,10 @@ class NonDefaultConstructibleSkeletalRichEnum
     using Base = SkeletalRichEnum<RichEnumType, BackingEnumType, InfusedDataProviderType>;
 
 public:
-    using BackingEnum = typename Base::BackingEnum;
-
-protected:
-    using ValuesFriend = typename Base::ValuesFriend;
-    using InfusedDataProvider = InfusedDataProviderType;
-    using InfusedData = typename InfusedDataProvider::DataType;
-
-public:
     constexpr NonDefaultConstructibleSkeletalRichEnum() noexcept = delete;
 
 protected:
-    explicit(false) constexpr NonDefaultConstructibleSkeletalRichEnum(
-        const BackingEnum& backing_enum) noexcept
-        requires(std::is_empty_v<InfusedData>)
-      : Base{backing_enum}
-    {
-    }
-
-    constexpr NonDefaultConstructibleSkeletalRichEnum(const BackingEnum& backing_enum,
-                                                      const InfusedData& enum_data) noexcept
-        requires(!std::is_empty_v<InfusedData>)
-      : Base{backing_enum, enum_data}
-    {
-    }
+    using Base::Base;
 };
 
 }  // namespace fixed_containers::rich_enums

--- a/include/fixed_containers/enum_utils.hpp
+++ b/include/fixed_containers/enum_utils.hpp
@@ -551,6 +551,17 @@ public:
         return this->detail_backing_enum == other.detail_backing_enum;
     }
 
+    constexpr const RichEnumType& operator!() const
+        requires std::is_same_v<bool, std::underlying_type_t<BackingEnum>>
+    {
+        if (*this == RichEnumType::values()[0])
+        {
+            return RichEnumType::values()[1];
+        }
+
+        return RichEnumType::values()[0];
+    }
+
     [[nodiscard]] constexpr bool has_value() const { return this->detail_backing_enum.has_value(); }
 
     [[nodiscard]] constexpr std::size_t ordinal() const
@@ -617,17 +628,6 @@ public:
     constexpr SkeletalRichEnum(SkeletalRichEnum&&) noexcept = default;
     constexpr SkeletalRichEnum& operator=(const SkeletalRichEnum&) noexcept = default;
     constexpr SkeletalRichEnum& operator=(SkeletalRichEnum&&) noexcept = default;
-
-    constexpr const RichEnumType& operator!() const
-        requires std::is_same_v<bool, std::underlying_type_t<BackingEnum>>
-    {
-        if (*this == RichEnumType::values()[0])
-        {
-            return RichEnumType::values()[1];
-        }
-
-        return RichEnumType::values()[0];
-    }
 
     [[nodiscard]] constexpr std::string_view to_string() const
     {

--- a/include/fixed_containers/enum_utils.hpp
+++ b/include/fixed_containers/enum_utils.hpp
@@ -183,9 +183,9 @@ constexpr std::optional<std::reference_wrapper<const RichEnum>> value_of(
     return std::nullopt;
 }
 
-template <class RichEnum, class BackingEnum>
+template <class RichEnum>
 constexpr std::optional<std::reference_wrapper<const RichEnum>> value_of(
-    const BackingEnum& backing_enum)
+    const typename RichEnum::BackingEnum& backing_enum)
 {
     const auto& rich_enum_values = RichEnum::values();
     const auto enum_integer = static_cast<std::size_t>(backing_enum);

--- a/include/fixed_containers/enum_utils.hpp
+++ b/include/fixed_containers/enum_utils.hpp
@@ -374,7 +374,7 @@ public:  // Public so this type is a structural type and can thus be used in tem
 }  // namespace fixed_containers::rich_enums_detail
 
 // MACRO to reduce four lines into one and avoid bugs from potential discrepancy between the
-// BackingEnum::CONSTANT_ITERATOR and the rich enum CONSTANT_ITERATOR()
+// BackingEnum::ENUM_CONSTANT and the rich enum ENUM_CONSTANT()
 // Must be used after the values() static function is declared in the rich enum.
 #define FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(RichEnumName, CONSTANT_NAME) \
     static constexpr const RichEnumName& CONSTANT_NAME()                            \

--- a/include/fixed_containers/enum_utils.hpp
+++ b/include/fixed_containers/enum_utils.hpp
@@ -603,7 +603,7 @@ public:
     {
         if (this->has_value())
         {
-            return magic_enum::enum_name(this->detail_backing_enum.value());
+            return magic_enum::enum_name(this->backing_enum());
         }
         return INVALID_TO_STRING;
     }

--- a/include/fixed_containers/enum_utils.hpp
+++ b/include/fixed_containers/enum_utils.hpp
@@ -619,7 +619,7 @@ public:
     constexpr SkeletalRichEnum& operator=(SkeletalRichEnum&&) noexcept = default;
 
     constexpr const RichEnumType& operator!() const
-        requires std::is_same_v<bool, magic_enum::underlying_type_t<BackingEnum>>
+        requires std::is_same_v<bool, std::underlying_type_t<BackingEnum>>
     {
         if (*this == RichEnumType::values()[0])
         {

--- a/test/enum_utils_test.cpp
+++ b/test/enum_utils_test.cpp
@@ -75,6 +75,12 @@ enum class SortedContiguousValuesTestEnum4
 static_assert(std::is_trivially_copyable_v<TestRichEnum1>);
 static_assert(!std::is_trivial_v<TestRichEnum1>);
 static_assert(std::is_standard_layout_v<TestRichEnum1>);
+static_assert(std::is_default_constructible_v<TestRichEnum1>);
+
+static_assert(std::is_trivially_copyable_v<TestRichEnum2>);
+static_assert(!std::is_trivial_v<TestRichEnum2>);
+static_assert(std::is_standard_layout_v<TestRichEnum2>);
+static_assert(!std::is_default_constructible_v<TestRichEnum2>);
 
 static_assert(!is_rich_enum<CustomValuesTestEnum1>);
 static_assert(
@@ -86,6 +92,9 @@ static_assert(
 
 static_assert(is_rich_enum<TestRichEnum1>);
 static_assert(has_enum_adapter<TestRichEnum1>);
+
+static_assert(is_rich_enum<TestRichEnum2>);
+static_assert(has_enum_adapter<TestRichEnum2>);
 
 static_assert(!is_rich_enum<NonConformingTestRichEnum1>);
 static_assert(has_enum_adapter<NonConformingTestRichEnum1>);

--- a/test/enum_utils_test.cpp
+++ b/test/enum_utils_test.cpp
@@ -203,35 +203,77 @@ TEST(SpecializedEnumAdapter, ToString)
                                   NonConformingTestRichEnum1::NC_TWO()));
 }
 
-TEST(RichEnum, ValueOfInt)
+TEST(RichEnum, Ordinal)
 {
-    constexpr const TestRichEnum1& MY_VALUE = TestRichEnum1::value_of(0).value();
+    {
+        static_assert(TestRichEnum1::C_ONE().ordinal() == 0);
+        static_assert(TestRichEnum1::C_TWO().ordinal() == 1);
+        static_assert(TestRichEnum1::C_THREE().ordinal() == 2);
+        static_assert(TestRichEnum1::C_FOUR().ordinal() == 3);
+    }
 
-    static_assert(MY_VALUE == TestRichEnum1::C_ONE());
-    static_assert(&MY_VALUE == &TestRichEnum1::C_ONE());
-
-    static_assert(TestRichEnum1::value_of(29) == std::nullopt);
+    {
+        static_assert(TestRichEnum2::C_ONE().ordinal() == 0);
+        static_assert(TestRichEnum2::C_TWO().ordinal() == 1);
+        static_assert(TestRichEnum2::C_THREE().ordinal() == 2);
+        static_assert(TestRichEnum2::C_FOUR().ordinal() == 3);
+    }
 }
 
 TEST(RichEnum, ValueOfName)
 {
-    constexpr const TestRichEnum1& MY_VALUE = TestRichEnum1::value_of("C_ONE").value();
+    {
+        static_assert(TestRichEnum1::value_of("C_ONE") == TestRichEnum1::C_ONE());
+        static_assert(TestRichEnum1::value_of("C_TWO") == TestRichEnum1::C_TWO());
+        static_assert(TestRichEnum1::value_of("C_THREE") == TestRichEnum1::C_THREE());
+        static_assert(TestRichEnum1::value_of("C_FOUR") == TestRichEnum1::C_FOUR());
+        static_assert(TestRichEnum1::value_of("INVALID") == std::nullopt);
+    }
 
-    static_assert(MY_VALUE == TestRichEnum1::C_ONE());
-    static_assert(&MY_VALUE == &TestRichEnum1::C_ONE());
+    {
+        constexpr const TestRichEnum1& MY_VALUE = TestRichEnum1::value_of("C_ONE").value();
 
-    static_assert(TestRichEnum1::value_of("INVALID") == std::nullopt);
+        static_assert(MY_VALUE == TestRichEnum1::C_ONE());
+        static_assert(&MY_VALUE == &TestRichEnum1::C_ONE());
+    }
 }
 
-TEST(RichEnum, BackingEnum)
+TEST(RichEnum, ValueOfBackingEnum)
 {
-    using BE = detail::TestRichEnum1BackingEnum;
-    constexpr const TestRichEnum1& MY_VALUE = TestRichEnum1::value_of(BE::C_ONE).value();
+    {
+        using BE = detail::TestRichEnum1BackingEnum;
+        static_assert(TestRichEnum1::value_of(BE::C_ONE) == TestRichEnum1::C_ONE());
+        static_assert(TestRichEnum1::value_of(BE::C_TWO) == TestRichEnum1::C_TWO());
+        static_assert(TestRichEnum1::value_of(BE::C_THREE) == TestRichEnum1::C_THREE());
+        static_assert(TestRichEnum1::value_of(BE::C_FOUR) == TestRichEnum1::C_FOUR());
+        static_assert(TestRichEnum1::value_of(static_cast<BE>(29)) == std::nullopt);
+    }
 
-    static_assert(MY_VALUE == TestRichEnum1::C_ONE());
-    static_assert(&MY_VALUE == &TestRichEnum1::C_ONE());
+    {
+        using BE = detail::TestRichEnum1BackingEnum;
+        constexpr const TestRichEnum1& MY_VALUE = TestRichEnum1::value_of(BE::C_ONE).value();
 
-    static_assert(TestRichEnum1::value_of(static_cast<BE>(29)) == std::nullopt);
+        static_assert(MY_VALUE == TestRichEnum1::C_ONE());
+        static_assert(&MY_VALUE == &TestRichEnum1::C_ONE());
+    }
+}
+
+TEST(RichEnum, ValueOfUnderlyingInt)
+{
+    {
+        static_assert(TestRichEnum1::value_of(19) == TestRichEnum1::C_ONE());
+        static_assert(TestRichEnum1::value_of(21) == TestRichEnum1::C_TWO());
+        static_assert(TestRichEnum1::value_of(23) == TestRichEnum1::C_THREE());
+        static_assert(TestRichEnum1::value_of(25) == TestRichEnum1::C_FOUR());
+        static_assert(TestRichEnum1::value_of(29) == std::nullopt);
+    }
+
+    {
+        constexpr const TestRichEnum1& MY_VALUE = TestRichEnum1::value_of(19).value();
+
+        static_assert(MY_VALUE == TestRichEnum1::C_ONE());
+        static_assert(&MY_VALUE == &TestRichEnum1::C_ONE());
+    }
 }
 
 TEST(RichEnum, UniqueValuesArrays)

--- a/test/enums_test_common.hpp
+++ b/test/enums_test_common.hpp
@@ -82,10 +82,10 @@ namespace detail
 {
 enum class TestRichEnum1BackingEnum : std::uint32_t
 {
-    C_ONE,
-    C_TWO,
-    C_THREE,
-    C_FOUR,
+    C_ONE = 19,
+    C_FOUR = 25,
+    C_TWO = 21,
+    C_THREE = 23,
 };
 
 // If we have data to associate with each enum constant, we can put them in a map here, then provide

--- a/test/enums_test_common.hpp
+++ b/test/enums_test_common.hpp
@@ -322,6 +322,7 @@ public:
     constexpr NonCopyableRichEnum& operator=(const NonCopyableRichEnum& other) = delete;
 
 public:
+    constexpr const BackingEnum& backing_enum() const { return backing_enum_; }
     constexpr std::size_t ordinal() const
     {
         return static_cast<std::size_t>(magic_enum::enum_integer(backing_enum_));


### PR DESCRIPTION
```C++
enum class TestRichEnum1BackingEnum : std::uint32_t
{
    C_ONE = 19,
    C_FOUR = 25,
    C_TWO = 21,
    C_THREE = 23,
};

static_assert(TestRichEnum1::C_ONE().ordinal() == 0);
static_assert(TestRichEnum1::C_TWO().ordinal() == 1);
static_assert(TestRichEnum1::C_THREE().ordinal() == 2);
static_assert(TestRichEnum1::C_FOUR().ordinal() == 3);

static_assert(TestRichEnum1::value_of(19) == TestRichEnum1::C_ONE());
static_assert(TestRichEnum1::value_of(21) == TestRichEnum1::C_TWO());
static_assert(TestRichEnum1::value_of(23) == TestRichEnum1::C_THREE());
static_assert(TestRichEnum1::value_of(25) == TestRichEnum1::C_FOUR());
static_assert(TestRichEnum1::value_of(29) == std::nullopt);
```