### PR TITLE
[FixedCircularBuffer] Add FixedCircularBuffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,8 @@ if(BUILD_TESTS)
     add_test_dependencies(string_literal_test)
     add_executable(type_name_test test/type_name_test.cpp)
     add_test_dependencies(type_name_test)
+    add_executable(fixed_circular_buffer_test test/fixed_circular_buffer_test.cpp)
+    add_test_dependencies(fixed_circular_buffer_test)
 endif()
 
 option(FIXED_CONTAINERS_OPT_INSTALL "Enable install target" ${PROJECT_IS_TOP_LEVEL})

--- a/include/fixed_containers/fixed_circular_buffer.hpp
+++ b/include/fixed_containers/fixed_circular_buffer.hpp
@@ -1,0 +1,248 @@
+#pragma once
+
+#include "fixed_containers/fixed_deque.hpp"
+#include "fixed_containers/sequence_container_checking.hpp"
+#include "fixed_containers/source_location.hpp"
+
+namespace fixed_containers
+{
+template <typename T,
+          std::size_t MAXIMUM_SIZE,
+          customize::SequenceContainerChecking CheckingType =
+              customize::SequenceContainerAbortChecking<T, MAXIMUM_SIZE>>
+class FixedCircularBuffer
+{
+public:
+    using container_type = FixedDeque<T, MAXIMUM_SIZE, CheckingType>;
+    using value_type = typename container_type::value_type;
+    using size_type = typename container_type::size_type;
+    using reference = typename container_type::reference;
+    using const_reference = typename container_type::const_reference;
+    using iterator = typename container_type::iterator;
+    using const_iterator = typename container_type::const_iterator;
+    using reverse_iterator = typename container_type::reverse_iterator;
+    using const_reverse_iterator = typename container_type::const_reverse_iterator;
+
+public:  // Public so this type is a structural type and can thus be used in template parameters
+    container_type IMPLEMENTATION_DETAIL_DO_NOT_USE_data_;
+    std::size_t IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_;
+
+public:
+    constexpr FixedCircularBuffer()
+      : IMPLEMENTATION_DETAIL_DO_NOT_USE_data_{}
+      , IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_{0}
+    {
+    }
+
+    template <InputIterator InputIt>
+    constexpr FixedCircularBuffer(InputIt first,
+                                  InputIt last,
+                                  const std_transition::source_location& loc =
+                                      std_transition::source_location::current()) noexcept
+      : IMPLEMENTATION_DETAIL_DO_NOT_USE_data_(first, last, loc)
+      , IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_(IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.size()-1)
+    {
+    }
+
+public:
+    constexpr void clear() noexcept
+    {
+        IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.clear();
+    }
+
+    constexpr iterator begin() noexcept
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.begin();
+    }
+    constexpr const_iterator begin() const noexcept { return cbegin(); }
+    constexpr const_iterator cbegin() const noexcept
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.cbegin();
+    }
+    constexpr iterator end() noexcept
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.end();
+    }
+    constexpr const_iterator end() const noexcept { return cend(); }
+    constexpr const_iterator cend() const noexcept
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.cend();
+    }
+
+    constexpr reverse_iterator rbegin() noexcept
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.rbegin();
+    }
+    constexpr const_reverse_iterator rbegin() const noexcept { return crbegin(); }
+    constexpr const_reverse_iterator crbegin() const noexcept
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.crbegin();
+    }
+    constexpr reverse_iterator rend() noexcept
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.rend();
+    }
+    constexpr const_reverse_iterator rend() const noexcept { return crend(); }
+    constexpr const_reverse_iterator crend() const noexcept
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.crend();
+    }
+
+    [[nodiscard]] constexpr std::size_t max_size() const noexcept { return MAXIMUM_SIZE; }
+    [[nodiscard]] constexpr std::size_t size() const noexcept
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.size();
+    }
+    [[nodiscard]] constexpr bool empty() const noexcept
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.empty();
+    }
+
+    constexpr reference operator[](size_type i) noexcept
+    {
+        // Cannot capture real source_location for operator[]
+        // This operator should not range-check according to the spec, but we want the extra safety.
+        return at(i, std_transition::source_location::current());
+    }
+    constexpr const_reference operator[](size_type i) const noexcept
+    {
+        // Cannot capture real source_location for operator[]
+        // This operator should not range-check according to the spec, but we want the extra safety.
+        return at(i, std_transition::source_location::current());
+    }
+
+    constexpr reference at(size_type i,
+                           const std_transition::source_location& loc =
+                               std_transition::source_location::current()) noexcept
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.at(i, loc);
+    }
+    constexpr const_reference at(size_type i,
+                                 const std_transition::source_location& loc =
+                                     std_transition::source_location::current()) const noexcept
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.at(i, loc);
+    }
+
+    constexpr reference front(
+        const std_transition::source_location& loc = std_transition::source_location::current())
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.front(loc);
+    }
+    constexpr const_reference front(const std_transition::source_location& loc =
+                                        std_transition::source_location::current()) const
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.front(loc);
+    }
+
+    constexpr reference back(
+        const std_transition::source_location& loc = std_transition::source_location::current())
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.back(loc);
+    }
+    constexpr const_reference back(const std_transition::source_location& loc =
+                                       std_transition::source_location::current()) const
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.back(loc);
+    }
+
+    constexpr void push(
+        const value_type& value,
+        const std_transition::source_location& loc = std_transition::source_location::current())
+    {
+        if (!is_full(IMPLEMENTATION_DETAIL_DO_NOT_USE_data_))
+        {
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.push_back(value, loc);
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ = IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.size()-1;
+        } else {
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ = (IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ + 1) % IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.max_size();
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.place_at(IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_, value);
+        }
+    }
+    constexpr void push(
+        value_type&& value,
+        const std_transition::source_location& loc = std_transition::source_location::current())
+    {
+        if (!is_full(IMPLEMENTATION_DETAIL_DO_NOT_USE_data_))
+        {
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.push_back(std::move(value), loc);
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ = IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.size()-1;
+        }
+        else
+        {
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ = (IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ + 1) % IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.max_size();
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.place_at(IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_, std::move(value));
+        }
+    }
+
+    template <class... Args>
+    constexpr decltype(auto) emplace(Args&&... args)
+    {
+        if (!is_full(IMPLEMENTATION_DETAIL_DO_NOT_USE_data_))
+        {
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.emplace_back(std::forward<Args>(args)...);
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ = IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.size()-1;
+        }
+        else
+        {
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ = (IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ + 1) % IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.max_size();
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.emplace_at(IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_, std::forward<Args>(args)...);
+        }
+    }
+
+    constexpr void pop(
+        const std_transition::source_location& loc = std_transition::source_location::current())
+    {
+        IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.pop_front(loc);
+        if (!is_full(IMPLEMENTATION_DETAIL_DO_NOT_USE_data_))
+        {
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ =
+                (IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ == 0)
+                    ? IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.size() - 1
+                    : (IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ - 1) %
+                          IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.size();
+        }
+        else
+        {
+            IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ =
+                (IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ == 0)
+                    ? IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.max_size() - 1
+                    : (IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ - 1) %
+                          IMPLEMENTATION_DETAIL_DO_NOT_USE_data_.max_size();
+        }
+    }
+
+    template <std::size_t MAXIMUM_SIZE_2, customize::SequenceContainerChecking CheckingType2>
+    constexpr bool operator==(const FixedCircularBuffer<T, MAXIMUM_SIZE_2, CheckingType2>& other) const
+    {
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_ ==
+                   other.IMPLEMENTATION_DETAIL_DO_NOT_USE_data_ && IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ == other.IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_;
+    }
+
+    template <std::size_t MAXIMUM_SIZE_2, customize::SequenceContainerChecking CheckingType2>
+    constexpr auto operator<=>(const FixedCircularBuffer<T, MAXIMUM_SIZE_2, CheckingType2>& other) const
+    {
+        //if (auto cmp = IMPLEMENTATION_DETAIL_DO_NOT_USE_data_ <=> other.IMPLEMENTATION_DETAIL_DO_NOT_USE_data_; cmp != 0)
+        //    return cmp;
+        //if (auto cmp = IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_ <=> other.IMPLEMENTATION_DETAIL_DO_NOT_USE_cursor_; cmp != 0)
+        //    return cmp;
+        return IMPLEMENTATION_DETAIL_DO_NOT_USE_data_ <=>
+               other.IMPLEMENTATION_DETAIL_DO_NOT_USE_data_;
+    }
+};
+
+template <typename T, std::size_t MAXIMUM_SIZE, typename CheckingType>
+[[nodiscard]] constexpr typename FixedCircularBuffer<T, MAXIMUM_SIZE, CheckingType>::size_type is_full(
+    const FixedCircularBuffer<T, MAXIMUM_SIZE, CheckingType>& c)
+{
+    return c.size() >= MAXIMUM_SIZE;
+}
+
+template <typename T, std::size_t MAXIMUM_SIZE, typename CheckingType>
+[[nodiscard]] constexpr typename FixedCircularBuffer<T, MAXIMUM_SIZE, CheckingType>::size_type available(
+    const FixedCircularBuffer<T, MAXIMUM_SIZE, CheckingType>& c)
+{
+    return MAXIMUM_SIZE - c.size();
+}
+
+}  // namespace fixed_containers

--- a/include/fixed_containers/fixed_deque.hpp
+++ b/include/fixed_containers/fixed_deque.hpp
@@ -783,6 +783,8 @@ private:
         }
     }
 
+    // [WORKAROUND-1] - Needed by FixedCircularBuffer
+public:
     constexpr void place_at(const std::size_t i, const value_type& v)
     {
         std::construct_at(&array_unchecked_at(i), v);

--- a/test/fixed_circular_buffer_test.cpp
+++ b/test/fixed_circular_buffer_test.cpp
@@ -1,0 +1,335 @@
+#include "fixed_containers/fixed_circular_buffer.hpp"
+
+#include "fixed_containers/fixed_vector.hpp"
+
+#include <gtest/gtest.h>
+
+namespace fixed_containers
+{
+
+using CircualrBufferType = FixedCircularBuffer<int, 5>;
+static_assert(TriviallyCopyable<CircualrBufferType>);
+static_assert(NotTrivial<CircualrBufferType>);
+static_assert(StandardLayout<CircualrBufferType>);
+static_assert(IsStructuralType<CircualrBufferType>);
+static_assert(ConstexprDefaultConstructible<CircualrBufferType>);
+
+TEST(FixedCircularBuffer, DefaultConstructor)
+{
+    constexpr FixedCircularBuffer<int, 8> v1{};
+    (void)v1;
+}
+
+TEST(FixedCircularBuffer, IteratorConstructor)
+{
+    constexpr FixedCircularBuffer<int, 3> s1 = []()
+    {
+        FixedVector<int, 3> v1{77, 99};
+        return FixedCircularBuffer<int, 3>{v1.begin(), v1.end()};
+    }();
+
+    static_assert(s1.front() == 77);
+    static_assert(s1.size() == 2);
+}
+
+TEST(FixedCircularBuffer, MaxSize)
+{
+    {
+        constexpr FixedCircularBuffer<int, 3> v1{};
+        static_assert(v1.max_size() == 3);
+    }
+
+    {
+        FixedCircularBuffer<int, 3> v1{};
+        EXPECT_EQ(3, v1.max_size());
+    }
+}
+
+TEST(FixedCircularBuffer, Empty)
+{
+    constexpr auto v1 = []() { return FixedCircularBuffer<int, 7>{}; }();
+
+    static_assert(v1.empty());
+    static_assert(v1.max_size() == 7);
+
+    EXPECT_TRUE(available(v1) == 7);
+}
+
+TEST(FixedCircularBuffer, Front)
+{
+    {
+        constexpr FixedCircularBuffer<int, 3> s1 = []()
+        {
+            FixedVector<int, 3> v1{77, 99};
+            return FixedCircularBuffer<int, 3>{v1.begin(), v1.end()};
+        }();
+
+        static_assert(s1.front() == 77);
+        static_assert(s1.size() == 2);
+    }
+
+    {
+        FixedCircularBuffer<int, 3> s1 = []()
+        {
+            FixedVector<int, 3> v1{77, 99};
+            return FixedCircularBuffer<int, 3>{v1.begin(), v1.end()};
+        }();
+
+        ASSERT_EQ(77, s1.front());
+        ASSERT_EQ(2, s1.size());
+    }
+}
+
+TEST(FixedCircularBuffer, Back)
+{
+    {
+        constexpr FixedCircularBuffer<int, 3> s1 = []()
+        {
+            FixedVector<int, 3> v1{77, 99};
+            return FixedCircularBuffer<int, 3>{v1.begin(), v1.end()};
+        }();
+
+        static_assert(s1.back() == 99);
+        static_assert(s1.size() == 2);
+    }
+
+    {
+        FixedCircularBuffer<int, 3> s1 = []()
+        {
+            FixedVector<int, 3> v1{77, 99};
+            return FixedCircularBuffer<int, 3>{v1.begin(), v1.end()};
+        }();
+
+        ASSERT_EQ(99, s1.back());
+        ASSERT_EQ(2, s1.size());
+    }
+}
+
+TEST(FixedCircularBuffer, Push)
+{
+    constexpr FixedCircularBuffer<int, 3> s1 = []()
+    {
+        FixedCircularBuffer<int, 3> v1{};
+        int my_int = 77;
+        v1.push(my_int);
+        v1.push(99);
+        return v1;
+    }();
+
+    static_assert(s1.front() == 77);
+    static_assert(s1.size() == 2);
+
+    EXPECT_TRUE(available(s1) == 1);
+}
+
+TEST(FixedCircularBuffer, Emplace)
+{
+    constexpr FixedCircularBuffer<int, 3> s1 = []()
+    {
+        FixedCircularBuffer<int, 3> v1{};
+        int my_int = 77;
+        v1.emplace(my_int);
+        v1.emplace(99);
+        return v1;
+    }();
+
+    static_assert(s1.front() == 77);
+    static_assert(s1.size() == 2);
+}
+
+TEST(FixedCircularBuffer, Pop)
+{
+    constexpr FixedCircularBuffer<int, 3> s1 = []()
+    {
+        FixedVector<int, 3> v1{77, 99};
+        FixedCircularBuffer<int, 3> out{v1.begin(), v1.end()};
+        out.pop();
+        return out;
+    }();
+
+    static_assert(s1.front() == 99);
+    static_assert(s1.size() == 1);
+}
+
+TEST(FixedCircularBuffer, Equality)
+{
+    static constexpr std::array<int, 2> a1{1, 2};
+    static constexpr std::array<int, 3> a2{1, 2, 3};
+
+    constexpr FixedCircularBuffer<int, 4> s1{a1.begin(), a1.end()};
+    constexpr FixedCircularBuffer<int, 4> s2{a1.begin(), a1.end()};
+    constexpr FixedCircularBuffer<int, 4> s3{a2.begin(), a2.end()};
+
+    static_assert(s1 == s2);
+    static_assert(s1 != s3);
+}
+
+TEST(FixedCircularBuffer, Comparison)
+{
+    static constexpr std::array<int, 2> a1{1, 2};
+    static constexpr std::array<int, 3> a2{1, 3};
+
+    constexpr FixedCircularBuffer<int, 4> s1{a1.begin(), a1.end()};
+    constexpr FixedCircularBuffer<int, 4> s2{a2.begin(), a2.end()};
+
+    static_assert(s1 < s2);
+    static_assert(s1 <= s2);
+    static_assert(s2 > s1);
+    static_assert(s2 >= s1);
+}
+
+TEST(FixedCircularBuffer, Full)
+{
+    constexpr auto v1 = []()
+    {
+        FixedCircularBuffer<int, 4> v{};
+        v.push(100);
+        v.push(100);
+        v.push(100);
+        v.push(100);
+        return v;
+    }();
+
+    static_assert(is_full(v1));
+    static_assert(v1.size() == 4);
+    static_assert(v1.max_size() == 4);
+
+    EXPECT_TRUE(is_full(v1));
+    EXPECT_TRUE(available(v1) == 0);
+}
+
+TEST(FixedCircularBuffer, PushFull)
+{
+    constexpr auto v1 = []()
+    {
+        FixedCircularBuffer<int, 4> v{};
+        v.push(100);
+        v.push(100);
+        v.push(100);
+        v.push(100);
+        v.push(99);
+        return v;
+    }();
+
+    static_assert(is_full(v1));
+    static_assert(v1.size() == 4);
+    static_assert(v1.max_size() == 4);
+    static_assert(v1.front() == 99);
+
+    EXPECT_TRUE(is_full(v1));
+    EXPECT_EQ(99, v1[0]);
+    EXPECT_EQ(100, v1[1]);
+    EXPECT_EQ(100, v1[2]);
+    EXPECT_EQ(100, v1[3]);
+}
+
+TEST(FixedCircularBuffer, PushFull2)
+{
+    constexpr auto v1 = []()
+    {
+        FixedCircularBuffer<int, 4> v{};
+        v.push(100);
+        v.push(101);
+        v.push(102);
+        v.push(103);
+        v.push(99);
+        v.push(77);
+        return v;
+    }();
+
+    static_assert(is_full(v1));
+    static_assert(v1.size() == 4);
+    static_assert(v1.max_size() == 4);
+    static_assert(v1.front() == 99);
+
+    EXPECT_TRUE(is_full(v1));
+    EXPECT_EQ(99, v1[0]);
+    EXPECT_EQ(77, v1[1]);
+    EXPECT_EQ(102, v1[2]);
+    EXPECT_EQ(103, v1[3]);
+}
+
+TEST(FixedCircularBuffer, EmplaceFull)
+{
+    constexpr FixedCircularBuffer<int, 4> s1 = []()
+    {
+        FixedCircularBuffer<int, 4> v{};
+        v.push(101);
+        v.push(102);
+        v.push(103);
+        v.push(104);
+        int my_int = 77;
+        v.emplace(my_int);
+        v.emplace(99);
+        return v;
+    }();
+
+    static_assert(s1.front() == 77);
+    static_assert(s1.back() == 104);
+    static_assert(s1.size() == 4);
+
+    EXPECT_TRUE(is_full(s1));
+    EXPECT_EQ(77, s1[0]);
+    EXPECT_EQ(99, s1[1]);
+    EXPECT_EQ(103, s1[2]);
+    EXPECT_EQ(104, s1[3]);
+}
+
+TEST(FixedCircularBuffer, PopFull)
+{
+    constexpr FixedCircularBuffer<int, 3> s1 = []()
+    {
+        FixedVector<int, 3> v1{77, 99, 88};
+        FixedCircularBuffer<int, 3> out{v1.begin(), v1.end()};
+        out.pop();
+        return out;
+    }();
+
+    static_assert(s1.front() == 99);
+    static_assert(s1.size() == 2);
+
+    EXPECT_FALSE(is_full(s1));
+    EXPECT_EQ(99, s1[0]);
+    EXPECT_EQ(88, s1[1]);
+}
+
+TEST(FixedCircularBuffer, ClassTemplateArgumentDeduction)
+{
+    // Compile-only test
+    FixedCircularBuffer a = FixedCircularBuffer<int, 5>{};
+    (void)a;
+}
+
+namespace
+{
+template <FixedCircularBuffer<int, 5> /*MY_QUEUE*/>
+struct FixedCircularBufferInstanceCanBeUsedAsATemplateParameter
+{
+};
+
+template <FixedCircularBuffer<int, 5> /*MY_QUEUE*/>
+constexpr void fixed_circular_buffer_instance_can_be_used_as_a_template_parameter()
+{
+}
+}  // namespace
+
+TEST(FixedCircularBuffer, UsageAsTemplateParameter)
+{
+    static constexpr FixedCircularBuffer<int, 5> QUEUE1{};
+    fixed_circular_buffer_instance_can_be_used_as_a_template_parameter<QUEUE1>();
+    FixedCircularBufferInstanceCanBeUsedAsATemplateParameter<QUEUE1> my_struct{};
+    static_cast<void>(my_struct);
+}
+
+}  // namespace fixed_containers
+
+namespace another_namespace_unrelated_to_the_fixed_containers_namespace
+{
+TEST(FixedCircularBuffer, ArgumentDependentLookup)
+{
+    // Compile-only test
+    fixed_containers::FixedCircularBuffer<int, 5> a{};
+    (void)is_full(a);
+    (void)available(a);
+}
+}  // namespace another_namespace_unrelated_to_the_fixed_containers_namespace


### PR DESCRIPTION
Hi, 
I added a first `FixedCircularBuffer` implementation (#76) (you can use it as a draft and extend it). I added some features I use on my own.

- Use some parts of [ETL circular_buffer](https://www.etlcpp.com/circular_buffer.html) https://www.etlcpp.com/circular_buffer.html
- Based on `FixedQueue` (uses `FixedDeque`)
- TODO: add in BUILD.bazel

_was not sure if or how to use `CircularIntegerRangeIterator`, so I used a plain `size_t` for the buffer cursor._  
_Had to make some methods `public` in `FixedDeque`_