### PR TITLE
EnumArray Ranges Constructor Should Forward Values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ user.bazelrc
 
 ### vcpkg ###
 vcpkg_installed/*
+
+### ctags ###
+tags

--- a/include/fixed_containers/enum_array.hpp
+++ b/include/fixed_containers/enum_array.hpp
@@ -79,10 +79,10 @@ public:
         requires DefaultConstructible<T>
       : EnumArray()
     {
-        for (const auto& [label, value] : rg)
+        for (auto&& [label, value] : rg)
         {
             const std::size_t ordinal = EnumAdapterType::ordinal(label);
-            values_.at(ordinal) = value;
+            values_.at(ordinal) = std::forward<decltype(value)>(value);
         }
     }
 

--- a/test/enum_array_test.cpp
+++ b/test/enum_array_test.cpp
@@ -91,6 +91,13 @@ TEST(EnumArray, RangeConstructor)
     static_assert(consteval_compare::equal<40, s1.at(TestEnum1::FOUR)>);
 }
 
+TEST(EnumArray, RangeConstructorMoveOnly)
+{
+    // Compile only check that the range constructor moves r-values
+    EnumArray<TestEnum1, MockMoveableButNotCopyable> s1{fixed_containers::std_transition::from_range, std::array{std::make_pair(TestEnum1::ONE,MockMoveableButNotCopyable()),
+                                                                                                                 std::make_pair(TestEnum1::TWO,MockMoveableButNotCopyable())}};
+}
+
 TEST(EnumArray, At)
 {
     {

--- a/test/enum_array_test.cpp
+++ b/test/enum_array_test.cpp
@@ -94,8 +94,10 @@ TEST(EnumArray, RangeConstructor)
 TEST(EnumArray, RangeConstructorMoveOnly)
 {
     // Compile only check that the range constructor moves r-values
-    EnumArray<TestEnum1, MockMoveableButNotCopyable> s1{fixed_containers::std_transition::from_range, std::array{std::make_pair(TestEnum1::ONE,MockMoveableButNotCopyable()),
-                                                                                                                 std::make_pair(TestEnum1::TWO,MockMoveableButNotCopyable())}};
+    constexpr EnumArray<TestEnum1, MockMoveableButNotCopyable> s1{
+        fixed_containers::std_transition::from_range,
+        std::array{std::make_pair(TestEnum1::ONE, MockMoveableButNotCopyable()),
+                   std::make_pair(TestEnum1::TWO, MockMoveableButNotCopyable())}};
 }
 
 TEST(EnumArray, At)


### PR DESCRIPTION
Added test for enumarray range constructor with moveonly types. Confirmed that the test fails to compile without the newly added std::forwarded since it tries to make a copy of the moveonly type.