### PR TITLE
Improve disabling of structured binding to be metaprogramming friendly 

### DIFF
--- a/include/fixed_containers/enum_array.hpp
+++ b/include/fixed_containers/enum_array.hpp
@@ -179,7 +179,6 @@ namespace std
 template <typename L, typename T>
 struct tuple_size<fixed_containers::EnumArray<L, T>> : std::integral_constant<std::size_t, 0>
 {
-    static_assert(fixed_containers::AlwaysFalseV<L, T>,
-                  "Implicit Structured Binding due to the fields being public is disabled");
+    // Implicit Structured Binding due to the fields being public is disabled
 };
 }  // namespace std

--- a/include/fixed_containers/enum_map.hpp
+++ b/include/fixed_containers/enum_map.hpp
@@ -1064,7 +1064,6 @@ template <typename K, typename V, fixed_containers::customize::EnumMapChecking<K
 struct tuple_size<fixed_containers::EnumMap<K, V, CheckingType>>
   : std::integral_constant<std::size_t, 0>
 {
-    static_assert(fixed_containers::AlwaysFalseV<K, V, CheckingType>,
-                  "Implicit Structured Binding due to the fields being public is disabled");
+    // Implicit Structured Binding due to the fields being public is disabled
 };
 }  // namespace std

--- a/include/fixed_containers/enum_set.hpp
+++ b/include/fixed_containers/enum_set.hpp
@@ -426,7 +426,6 @@ namespace std
 template <typename K>
 struct tuple_size<fixed_containers::EnumSet<K>> : std::integral_constant<std::size_t, 0>
 {
-    static_assert(fixed_containers::AlwaysFalseV<K>,
-                  "Implicit Structured Binding due to the fields being public is disabled");
+    // Implicit Structured Binding due to the fields being public is disabled
 };
 }  // namespace std

--- a/include/fixed_containers/fixed_circular_deque.hpp
+++ b/include/fixed_containers/fixed_circular_deque.hpp
@@ -530,7 +530,6 @@ template <typename T,
 struct tuple_size<fixed_containers::FixedCircularDeque<T, MAXIMUM_SIZE, CheckingType>>
   : std::integral_constant<std::size_t, 0>
 {
-    static_assert(fixed_containers::AlwaysFalseV<T, decltype(MAXIMUM_SIZE), CheckingType>,
-                  "Implicit Structured Binding due to the fields being public is disabled");
+    // Implicit Structured Binding due to the fields being public is disabled
 };
 }  // namespace std

--- a/include/fixed_containers/fixed_circular_queue.hpp
+++ b/include/fixed_containers/fixed_circular_queue.hpp
@@ -55,7 +55,6 @@ template <typename T,
 struct tuple_size<fixed_containers::FixedCircularQueue<T, MAXIMUM_SIZE, CheckingType>>
   : std::integral_constant<std::size_t, 0>
 {
-    static_assert(fixed_containers::AlwaysFalseV<T, decltype(MAXIMUM_SIZE), CheckingType>,
-                  "Implicit Structured Binding due to the fields being public is disabled");
+    // Implicit Structured Binding due to the fields being public is disabled
 };
 }  // namespace std

--- a/include/fixed_containers/fixed_circular_queue.hpp
+++ b/include/fixed_containers/fixed_circular_queue.hpp
@@ -2,10 +2,10 @@
 
 #include "fixed_containers/concepts.hpp"
 #include "fixed_containers/fixed_circular_deque.hpp"
+#include "fixed_containers/max_size.hpp"
 #include "fixed_containers/queue_adapter.hpp"
 #include "fixed_containers/sequence_container_checking.hpp"
 #include "fixed_containers/source_location.hpp"
-#include "fixed_containers/max_size.hpp"
 
 namespace fixed_containers
 {

--- a/include/fixed_containers/fixed_deque.hpp
+++ b/include/fixed_containers/fixed_deque.hpp
@@ -1083,7 +1083,6 @@ template <typename T,
 struct tuple_size<fixed_containers::FixedDeque<T, MAXIMUM_SIZE, CheckingType>>
   : std::integral_constant<std::size_t, 0>
 {
-    static_assert(fixed_containers::AlwaysFalseV<T, decltype(MAXIMUM_SIZE), CheckingType>,
-                  "Implicit Structured Binding due to the fields being public is disabled");
+    // Implicit Structured Binding due to the fields being public is disabled
 };
 }  // namespace std

--- a/include/fixed_containers/fixed_map.hpp
+++ b/include/fixed_containers/fixed_map.hpp
@@ -812,9 +812,6 @@ struct tuple_size<
         FixedMap<K, V, MAXIMUM_SIZE, Compare, COMPACTNESS, StorageTemplate, CheckingType>>
   : std::integral_constant<std::size_t, 0>
 {
-    static_assert(
-        fixed_containers::
-            AlwaysFalseV<K, decltype(MAXIMUM_SIZE), Compare, decltype(COMPACTNESS), CheckingType>,
-        "Implicit Structured Binding due to the fields being public is disabled");
+    // Implicit Structured Binding due to the fields being public is disabled
 };
 }  // namespace std

--- a/include/fixed_containers/fixed_queue.hpp
+++ b/include/fixed_containers/fixed_queue.hpp
@@ -55,7 +55,6 @@ template <typename T,
 struct tuple_size<fixed_containers::FixedQueue<T, MAXIMUM_SIZE, CheckingType>>
   : std::integral_constant<std::size_t, 0>
 {
-    static_assert(fixed_containers::AlwaysFalseV<T, decltype(MAXIMUM_SIZE), CheckingType>,
-                  "Implicit Structured Binding due to the fields being public is disabled");
+    // Implicit Structured Binding due to the fields being public is disabled
 };
 }  // namespace std

--- a/include/fixed_containers/fixed_set.hpp
+++ b/include/fixed_containers/fixed_set.hpp
@@ -536,9 +536,6 @@ struct tuple_size<
         FixedSet<K, MAXIMUM_SIZE, Compare, COMPACTNESS, StorageTemplate, CheckingType>>
   : std::integral_constant<std::size_t, 0>
 {
-    static_assert(
-        fixed_containers::
-            AlwaysFalseV<K, decltype(MAXIMUM_SIZE), Compare, decltype(COMPACTNESS), CheckingType>,
-        "Implicit Structured Binding due to the fields being public is disabled");
+    // Implicit Structured Binding due to the fields being public is disabled
 };
 }  // namespace std

--- a/include/fixed_containers/fixed_stack.hpp
+++ b/include/fixed_containers/fixed_stack.hpp
@@ -57,7 +57,6 @@ template <typename T,
 struct tuple_size<fixed_containers::FixedStack<T, MAXIMUM_SIZE, CheckingType>>
   : std::integral_constant<std::size_t, 0>
 {
-    static_assert(fixed_containers::AlwaysFalseV<T, decltype(MAXIMUM_SIZE), CheckingType>,
-                  "Implicit Structured Binding due to the fields being public is disabled");
+    // Implicit Structured Binding due to the fields being public is disabled
 };
 }  // namespace std

--- a/include/fixed_containers/fixed_string.hpp
+++ b/include/fixed_containers/fixed_string.hpp
@@ -501,7 +501,6 @@ template <std::size_t MAXIMUM_LENGTH,
 struct tuple_size<fixed_containers::FixedString<MAXIMUM_LENGTH, CheckingType>>
   : std::integral_constant<std::size_t, 0>
 {
-    static_assert(fixed_containers::AlwaysFalseV<decltype(MAXIMUM_LENGTH), CheckingType>,
-                  "Implicit Structured Binding due to the fields being public is disabled");
+    // Implicit Structured Binding due to the fields being public is disabled
 };
 }  // namespace std

--- a/include/fixed_containers/fixed_vector.hpp
+++ b/include/fixed_containers/fixed_vector.hpp
@@ -1058,7 +1058,6 @@ template <typename T,
 struct tuple_size<fixed_containers::FixedVector<T, MAXIMUM_SIZE, CheckingType>>
   : std::integral_constant<std::size_t, 0>
 {
-    static_assert(fixed_containers::AlwaysFalseV<T, decltype(MAXIMUM_SIZE), CheckingType>,
-                  "Implicit Structured Binding due to the fields being public is disabled");
+    // Implicit Structured Binding due to the fields being public is disabled
 };
 }  // namespace std


### PR DESCRIPTION
A `static_assert` causes a compilation failures for any utility
that was trying to check if this type is a tuple (e.g. via concepts).
Setting tuple_size to 0 is sufficient for preventing structured binding;
remove the `static_assert`

https://github.com/teslamotors/fixed-containers/issues/94