### PR TITLE
[FixedVector] Fix double-destroy bug in `erase`

### DIFF
--- a/include/fixed_containers/algorithm.hpp
+++ b/include/fixed_containers/algorithm.hpp
@@ -5,10 +5,10 @@
 namespace fixed_containers::algorithm
 {
 // Similar to https://en.cppreference.com/w/cpp/algorithm/move_backward
-// but uses `std::construct_at()`
+// but uses relocation instead of assignment
 // There seems to be an issue with clang and setting the active union member in a constexpr context.
 template <class BidirIt1, class BidirIt2>
-constexpr BidirIt2 emplace_move_backward(BidirIt1 first, BidirIt1 last, BidirIt2 d_last)
+constexpr BidirIt2 uninitialized_relocate_backward(BidirIt1 first, BidirIt1 last, BidirIt2 d_last)
 {
     while (first != last)
     {

--- a/include/fixed_containers/algorithm.hpp
+++ b/include/fixed_containers/algorithm.hpp
@@ -4,9 +4,23 @@
 
 namespace fixed_containers::algorithm
 {
-// Similar to https://en.cppreference.com/w/cpp/algorithm/move_backward
-// but uses relocation instead of assignment
-// There seems to be an issue with clang and setting the active union member in a constexpr context.
+// Similar to https://en.cppreference.com/w/cpp/memory/uninitialized_move
+// but also destroys the source range
+template <class FwdIt1, class FwdIt2>
+constexpr FwdIt2 uninitialized_relocate(FwdIt1 first, FwdIt1 last, FwdIt2 d_first)
+{
+    while (first != last)
+    {
+        std::construct_at(&*d_first, std::move(*first));
+        std::destroy_at(&*first);
+        ++d_first;
+        ++first;
+    }
+    return d_first;
+}
+
+// Similar to https://en.cppreference.com/w/cpp/memory/uninitialized_move
+// but also destroys the source range
 template <class BidirIt1, class BidirIt2>
 constexpr BidirIt2 uninitialized_relocate_backward(BidirIt1 first, BidirIt1 last, BidirIt2 d_last)
 {

--- a/include/fixed_containers/fixed_deque.hpp
+++ b/include/fixed_containers/fixed_deque.hpp
@@ -565,7 +565,7 @@ private:
         auto read_end_it = std::next(read_start_it, value_count_to_move);
         auto write_end_it =
             std::next(read_start_it, static_cast<std::ptrdiff_t>(n) + value_count_to_move);
-        algorithm::emplace_move_backward(read_start_it, read_end_it, write_end_it);
+        algorithm::uninitialized_relocate_backward(read_start_it, read_end_it, write_end_it);
 
         return read_start_it;
     }

--- a/include/fixed_containers/fixed_deque.hpp
+++ b/include/fixed_containers/fixed_deque.hpp
@@ -408,11 +408,11 @@ public:
         iterator read_end_it = std::next(read_start_it, entry_count_to_move);
         iterator write_start_it = const_to_mutable_it(first);
 
-        // Clean out the gap
-        destroy_range(write_start_it, std::next(write_start_it, entry_count_to_remove));
-
         // Do the move
-        std::move(read_start_it, read_end_it, write_start_it);
+        iterator write_end_it = std::move(read_start_it, read_end_it, write_start_it);
+
+        // Clean out the tail
+        destroy_range(write_end_it, read_end_it);
 
         decrement_size(static_cast<std::size_t>(entry_count_to_remove));
         return write_start_it;

--- a/include/fixed_containers/fixed_deque.hpp
+++ b/include/fixed_containers/fixed_deque.hpp
@@ -408,11 +408,25 @@ public:
         iterator read_end_it = std::next(read_start_it, entry_count_to_move);
         iterator write_start_it = const_to_mutable_it(first);
 
-        // Do the move
-        iterator write_end_it = std::move(read_start_it, read_end_it, write_start_it);
+        if (!std::is_constant_evaluated())
+        {
+            // We can only use this when `!is_constant_evaluated`, since otherwise Clang
+            // complains about objects being accessed outside their lifetimes.
 
-        // Clean out the tail
-        destroy_range(write_end_it, read_end_it);
+            // Clean out the gap
+            destroy_range(write_start_it, std::next(write_start_it, entry_count_to_remove));
+
+            // Do the relocation
+            algorithm::uninitialized_relocate(read_start_it, read_end_it, write_start_it);
+        }
+        else
+        {
+            // Do the move
+            iterator write_end_it = std::move(read_start_it, read_end_it, write_start_it);
+
+            // Clean out the tail
+            destroy_range(write_end_it, read_end_it);
+        }
 
         decrement_size(static_cast<std::size_t>(entry_count_to_remove));
         return write_start_it;

--- a/include/fixed_containers/fixed_vector.hpp
+++ b/include/fixed_containers/fixed_vector.hpp
@@ -400,11 +400,11 @@ public:
         iterator read_end_it = std::next(read_start_it, entry_count_to_move);
         iterator write_start_it = const_to_mutable_it(first);
 
-        // Clean out the gap
-        destroy_range(write_start_it, std::next(write_start_it, entry_count_to_remove));
-
         // Do the move
-        std::move(read_start_it, read_end_it, write_start_it);
+        iterator write_end_it = std::move(read_start_it, read_end_it, write_start_it);
+
+        // Clean out the tail
+        destroy_range(write_end_it, read_end_it);
 
         decrement_size(static_cast<std::size_t>(entry_count_to_remove));
         return write_start_it;

--- a/include/fixed_containers/fixed_vector.hpp
+++ b/include/fixed_containers/fixed_vector.hpp
@@ -400,11 +400,25 @@ public:
         iterator read_end_it = std::next(read_start_it, entry_count_to_move);
         iterator write_start_it = const_to_mutable_it(first);
 
-        // Do the move
-        iterator write_end_it = std::move(read_start_it, read_end_it, write_start_it);
+        if (!std::is_constant_evaluated())
+        {
+            // We can only use this when `!is_constant_evaluated`, since otherwise Clang
+            // complains about objects being accessed outside their lifetimes.
 
-        // Clean out the tail
-        destroy_range(write_end_it, read_end_it);
+            // Clean out the gap
+            destroy_range(write_start_it, std::next(write_start_it, entry_count_to_remove));
+
+            // Do the relocation
+            algorithm::uninitialized_relocate(read_start_it, read_end_it, write_start_it);
+        }
+        else
+        {
+            // Do the move
+            iterator write_end_it = std::move(read_start_it, read_end_it, write_start_it);
+
+            // Clean out the tail
+            destroy_range(write_end_it, read_end_it);
+        }
 
         decrement_size(static_cast<std::size_t>(entry_count_to_remove));
         return write_start_it;

--- a/include/fixed_containers/fixed_vector.hpp
+++ b/include/fixed_containers/fixed_vector.hpp
@@ -578,7 +578,7 @@ private:
         auto read_end_it = std::next(read_start_it, value_count_to_move);
         auto write_end_it =
             std::next(read_start_it, static_cast<std::ptrdiff_t>(n) + value_count_to_move);
-        algorithm::emplace_move_backward(read_start_it, read_end_it, write_end_it);
+        algorithm::uninitialized_relocate_backward(read_start_it, read_end_it, write_end_it);
 
         return read_start_it;
     }

--- a/test/fixed_circular_deque_test.cpp
+++ b/test/fixed_circular_deque_test.cpp
@@ -2039,12 +2039,22 @@ TEST(FixedCircularDeque, EraseRange)
         static_assert(v1.size() == 4);
         static_assert(v1.max_size() == 8);
 
-        auto v2 = Factory::template create<int, 8>({2, 1, 4, 5, 0, 3});
+        {
+            auto v2 = Factory::template create<int, 8>({2, 1, 4, 5, 0, 3});
 
-        auto it = v2.erase(std::next(v2.begin(), 1), std::next(v2.cbegin(), 3));
-        EXPECT_EQ(it, std::next(v2.begin(), 1));
-        EXPECT_EQ(*it, 5);
-        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{2, 5, 0, 3}}));
+            auto it = v2.erase(std::next(v2.begin(), 1), std::next(v2.cbegin(), 3));
+            EXPECT_EQ(it, std::next(v2.begin(), 1));
+            EXPECT_EQ(*it, 5);
+            EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{2, 5, 0, 3}}));
+        }
+        {
+            auto v =
+                Factory::template create<std::vector<int>, 8>({{1, 2, 3}, {4, 5}, {}, {6, 7, 8}});
+            auto it = v.erase(v.begin(), std::next(v.begin(), 2));
+            EXPECT_EQ(it, v.begin());
+            EXPECT_EQ(v.size(), 2u);
+            EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{}, {6, 7, 8}}));
+        }
     };
 
     run_test(FixedCircularDequeInitialStateFirstIndex{});
@@ -2067,22 +2077,41 @@ TEST(FixedCircularDeque, EraseOne)
         static_assert(v1.size() == 4);
         static_assert(v1.max_size() == 8);
 
-        auto v2 = Factory::template create<int, 8>({2, 1, 4, 5, 0, 3});
+        {
+            auto v2 = Factory::template create<int, 8>({2, 1, 4, 5, 0, 3});
 
-        auto it = v2.erase(v2.begin());
-        EXPECT_EQ(it, v2.begin());
-        EXPECT_EQ(*it, 1);
-        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 5>{{1, 4, 5, 0, 3}}));
-        std::advance(it, 2);
-        it = v2.erase(it);
-        EXPECT_EQ(it, std::next(v2.begin(), 2));
-        EXPECT_EQ(*it, 0);
-        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{1, 4, 0, 3}}));
-        ++it;
-        it = v2.erase(it);
-        EXPECT_EQ(it, v2.cend());
-        // EXPECT_EQ(*it, 3);  // Not dereferenceable
-        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 3>{{1, 4, 0}}));
+            auto it = v2.erase(v2.begin());
+            EXPECT_EQ(it, v2.begin());
+            EXPECT_EQ(*it, 1);
+            EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 5>{{1, 4, 5, 0, 3}}));
+            std::advance(it, 2);
+            it = v2.erase(it);
+            EXPECT_EQ(it, std::next(v2.begin(), 2));
+            EXPECT_EQ(*it, 0);
+            EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{1, 4, 0, 3}}));
+            ++it;
+            it = v2.erase(it);
+            EXPECT_EQ(it, v2.cend());
+            // EXPECT_EQ(*it, 3);  // Not dereferenceable
+            EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 3>{{1, 4, 0}}));
+        }
+        {
+            auto v =
+                Factory::template create<std::vector<int>, 8>({{1, 2, 3}, {4, 5}, {}, {6, 7, 8}});
+            auto it = v.erase(v.begin());
+            EXPECT_EQ(it, v.begin());
+            EXPECT_EQ(v.size(), 3u);
+            EXPECT_TRUE(
+                std::ranges::equal(v, std::vector<std::vector<int>>{{4, 5}, {}, {6, 7, 8}}));
+            it = v.erase(std::next(v.begin(), 1));
+            EXPECT_EQ(it, std::next(v.begin(), 1));
+            EXPECT_EQ(v.size(), 2u);
+            EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{4, 5}, {6, 7, 8}}));
+            it = v.erase(std::next(v.begin(), 1));
+            EXPECT_EQ(it, v.end());
+            EXPECT_EQ(v.size(), 1u);
+            EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{4, 5}}));
+        }
     };
 
     run_test(FixedCircularDequeInitialStateFirstIndex{});

--- a/test/fixed_deque_test.cpp
+++ b/test/fixed_deque_test.cpp
@@ -1725,12 +1725,22 @@ TEST(FixedDeque, EraseRange)
         static_assert(v1.size() == 4);
         static_assert(v1.max_size() == 8);
 
-        auto v2 = Factory::template create<int, 8>({2, 1, 4, 5, 0, 3});
+        {
+            auto v2 = Factory::template create<int, 8>({2, 1, 4, 5, 0, 3});
 
-        auto it = v2.erase(std::next(v2.begin(), 1), std::next(v2.cbegin(), 3));
-        EXPECT_EQ(it, std::next(v2.begin(), 1));
-        EXPECT_EQ(*it, 5);
-        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{2, 5, 0, 3}}));
+            auto it = v2.erase(std::next(v2.begin(), 1), std::next(v2.cbegin(), 3));
+            EXPECT_EQ(it, std::next(v2.begin(), 1));
+            EXPECT_EQ(*it, 5);
+            EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{2, 5, 0, 3}}));
+        }
+        {
+            auto v =
+                Factory::template create<std::vector<int>, 8>({{1, 2, 3}, {4, 5}, {}, {6, 7, 8}});
+            auto it = v.erase(v.begin(), std::next(v.begin(), 2));
+            EXPECT_EQ(it, v.begin());
+            EXPECT_EQ(v.size(), 2u);
+            EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{}, {6, 7, 8}}));
+        }
     };
 
     run_test(FixedDequeInitialStateFirstIndex{});
@@ -1753,22 +1763,41 @@ TEST(FixedDeque, EraseOne)
         static_assert(v1.size() == 4);
         static_assert(v1.max_size() == 8);
 
-        auto v2 = Factory::template create<int, 8>({2, 1, 4, 5, 0, 3});
+        {
+            auto v2 = Factory::template create<int, 8>({2, 1, 4, 5, 0, 3});
 
-        auto it = v2.erase(v2.begin());
-        EXPECT_EQ(it, v2.begin());
-        EXPECT_EQ(*it, 1);
-        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 5>{{1, 4, 5, 0, 3}}));
-        std::advance(it, 2);
-        it = v2.erase(it);
-        EXPECT_EQ(it, std::next(v2.begin(), 2));
-        EXPECT_EQ(*it, 0);
-        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{1, 4, 0, 3}}));
-        ++it;
-        it = v2.erase(it);
-        EXPECT_EQ(it, v2.cend());
-        // EXPECT_EQ(*it, 3);  // Not dereferenceable
-        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 3>{{1, 4, 0}}));
+            auto it = v2.erase(v2.begin());
+            EXPECT_EQ(it, v2.begin());
+            EXPECT_EQ(*it, 1);
+            EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 5>{{1, 4, 5, 0, 3}}));
+            std::advance(it, 2);
+            it = v2.erase(it);
+            EXPECT_EQ(it, std::next(v2.begin(), 2));
+            EXPECT_EQ(*it, 0);
+            EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{1, 4, 0, 3}}));
+            ++it;
+            it = v2.erase(it);
+            EXPECT_EQ(it, v2.cend());
+            // EXPECT_EQ(*it, 3);  // Not dereferenceable
+            EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 3>{{1, 4, 0}}));
+        }
+        {
+            auto v =
+                Factory::template create<std::vector<int>, 8>({{1, 2, 3}, {4, 5}, {}, {6, 7, 8}});
+            auto it = v.erase(v.begin());
+            EXPECT_EQ(it, v.begin());
+            EXPECT_EQ(v.size(), 3u);
+            EXPECT_TRUE(
+                std::ranges::equal(v, std::vector<std::vector<int>>{{4, 5}, {}, {6, 7, 8}}));
+            it = v.erase(std::next(v.begin(), 1));
+            EXPECT_EQ(it, std::next(v.begin(), 1));
+            EXPECT_EQ(v.size(), 2u);
+            EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{4, 5}, {6, 7, 8}}));
+            it = v.erase(std::next(v.begin(), 1));
+            EXPECT_EQ(it, v.end());
+            EXPECT_EQ(v.size(), 1u);
+            EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{4, 5}}));
+        }
     };
 
     run_test(FixedDequeInitialStateFirstIndex{});

--- a/test/fixed_list_test.cpp
+++ b/test/fixed_list_test.cpp
@@ -1530,12 +1530,21 @@ TEST(FixedList, EraseRange)
     static_assert(v1.size() == 4);
     static_assert(v1.max_size() == 8);
 
-    FixedList<int, 8> v2{2, 1, 4, 5, 0, 3};
+    {
+        FixedList<int, 8> v2{2, 1, 4, 5, 0, 3};
 
-    auto it = v2.erase(std::next(v2.begin(), 1), std::next(v2.cbegin(), 3));
-    EXPECT_EQ(it, std::next(v2.begin(), 1));
-    EXPECT_EQ(*it, 5);
-    EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{2, 5, 0, 3}}));
+        auto it = v2.erase(std::next(v2.begin(), 1), std::next(v2.cbegin(), 3));
+        EXPECT_EQ(it, std::next(v2.begin(), 1));
+        EXPECT_EQ(*it, 5);
+        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{2, 5, 0, 3}}));
+    }
+    {
+        FixedList<std::vector<int>, 8> v = {{1, 2, 3}, {4, 5}, {}, {6, 7, 8}};
+        auto it = v.erase(v.begin(), std::next(v.begin(), 2));
+        EXPECT_EQ(it, v.begin());
+        EXPECT_EQ(v.size(), 2u);
+        EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{}, {6, 7, 8}}));
+    }
 }
 
 TEST(FixedList, EraseRange_Invalidation)
@@ -1581,22 +1590,39 @@ TEST(FixedList, EraseOne)
     static_assert(v1.size() == 4);
     static_assert(v1.max_size() == 8);
 
-    FixedList<int, 8> v2{2, 1, 4, 5, 0, 3};
+    {
+        FixedList<int, 8> v2{2, 1, 4, 5, 0, 3};
 
-    auto it = v2.erase(v2.begin());
-    EXPECT_EQ(it, v2.begin());
-    EXPECT_EQ(*it, 1);
-    EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 5>{{1, 4, 5, 0, 3}}));
-    std::advance(it, 2);
-    it = v2.erase(it);
-    EXPECT_EQ(it, std::next(v2.begin(), 2));
-    EXPECT_EQ(*it, 0);
-    EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{1, 4, 0, 3}}));
-    ++it;
-    it = v2.erase(it);
-    EXPECT_EQ(it, v2.cend());
-    // EXPECT_EQ(*it, 3); // Not dereferenceable
-    EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 3>{{1, 4, 0}}));
+        auto it = v2.erase(v2.begin());
+        EXPECT_EQ(it, v2.begin());
+        EXPECT_EQ(*it, 1);
+        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 5>{{1, 4, 5, 0, 3}}));
+        std::advance(it, 2);
+        it = v2.erase(it);
+        EXPECT_EQ(it, std::next(v2.begin(), 2));
+        EXPECT_EQ(*it, 0);
+        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{1, 4, 0, 3}}));
+        ++it;
+        it = v2.erase(it);
+        EXPECT_EQ(it, v2.cend());
+        // EXPECT_EQ(*it, 3); // Not dereferenceable
+        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 3>{{1, 4, 0}}));
+    }
+    {
+        FixedList<std::vector<int>, 8> v = {{1, 2, 3}, {4, 5}, {}, {6, 7, 8}};
+        auto it = v.erase(v.begin());
+        EXPECT_EQ(it, v.begin());
+        EXPECT_EQ(v.size(), 3u);
+        EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{4, 5}, {}, {6, 7, 8}}));
+        it = v.erase(std::next(v.begin(), 1));
+        EXPECT_EQ(it, std::next(v.begin(), 1));
+        EXPECT_EQ(v.size(), 2u);
+        EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{4, 5}, {6, 7, 8}}));
+        it = v.erase(std::next(v.begin(), 1));
+        EXPECT_EQ(it, v.end());
+        EXPECT_EQ(v.size(), 1u);
+        EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{4, 5}}));
+    }
 }
 
 TEST(FixedList, EraseOne_Invalidation)

--- a/test/fixed_vector_test.cpp
+++ b/test/fixed_vector_test.cpp
@@ -1608,13 +1608,20 @@ TEST(FixedVector, EraseRange)
     static_assert(std::ranges::equal(v1, std::array<int, 4>{0, 1, 4, 5}));
     static_assert(v1.size() == 4);
     static_assert(v1.max_size() == 8);
-
-    FixedVector<int, 8> v2{2, 1, 4, 5, 0, 3};
-
-    auto it = v2.erase(std::next(v2.begin(), 1), std::next(v2.cbegin(), 3));
-    EXPECT_EQ(it, std::next(v2.begin(), 1));
-    EXPECT_EQ(*it, 5);
-    EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{2, 5, 0, 3}}));
+    {
+        FixedVector<int, 8> v2{2, 1, 4, 5, 0, 3};
+        auto it = v2.erase(std::next(v2.begin(), 1), std::next(v2.cbegin(), 3));
+        EXPECT_EQ(it, std::next(v2.begin(), 1));
+        EXPECT_EQ(*it, 5);
+        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{2, 5, 0, 3}}));
+    }
+    {
+        FixedVector<std::vector<int>, 8> v = {{1, 2, 3}, {4, 5}, {}, {6, 7, 8}};
+        auto it = v.erase(v.begin(), std::next(v.begin(), 2));
+        EXPECT_EQ(it, v.begin());
+        EXPECT_EQ(v.size(), 2u);
+        EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{}, {6, 7, 8}}));
+    }
 }
 
 TEST(FixedVector, EraseOne)
@@ -1631,22 +1638,37 @@ TEST(FixedVector, EraseOne)
     static_assert(v1.size() == 4);
     static_assert(v1.max_size() == 8);
 
-    FixedVector<int, 8> v2{2, 1, 4, 5, 0, 3};
-
-    auto it = v2.erase(v2.begin());
-    EXPECT_EQ(it, v2.begin());
-    EXPECT_EQ(*it, 1);
-    EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 5>{{1, 4, 5, 0, 3}}));
-    std::advance(it, 2);
-    it = v2.erase(it);
-    EXPECT_EQ(it, std::next(v2.begin(), 2));
-    EXPECT_EQ(*it, 0);
-    EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{1, 4, 0, 3}}));
-    ++it;
-    it = v2.erase(it);
-    EXPECT_EQ(it, v2.cend());
-    // EXPECT_EQ(*it, 3); // Not dereferenceable
-    EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 3>{{1, 4, 0}}));
+    {
+        FixedVector<int, 8> v2{2, 1, 4, 5, 0, 3};
+        auto it = v2.erase(v2.begin());
+        EXPECT_EQ(it, v2.begin());
+        EXPECT_EQ(*it, 1);
+        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 5>{{1, 4, 5, 0, 3}}));
+        std::advance(it, 2);
+        it = v2.erase(it);
+        EXPECT_EQ(it, std::next(v2.begin(), 2));
+        EXPECT_EQ(*it, 0);
+        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 4>{{1, 4, 0, 3}}));
+        ++it;
+        it = v2.erase(it);
+        EXPECT_EQ(it, v2.cend());
+        EXPECT_TRUE(std::ranges::equal(v2, std::array<int, 3>{{1, 4, 0}}));
+    }
+    {
+        FixedVector<std::vector<int>, 8> v = {{1, 2, 3}, {4, 5}, {}, {6, 7, 8}};
+        auto it = v.erase(v.begin());
+        EXPECT_EQ(it, v.begin());
+        EXPECT_EQ(v.size(), 3u);
+        EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{4, 5}, {}, {6, 7, 8}}));
+        it = v.erase(std::next(v.begin(), 1));
+        EXPECT_EQ(it, std::next(v.begin(), 1));
+        EXPECT_EQ(v.size(), 2u);
+        EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{4, 5}, {6, 7, 8}}));
+        it = v.erase(std::next(v.begin(), 1));
+        EXPECT_EQ(it, v.end());
+        EXPECT_EQ(v.size(), 1u);
+        EXPECT_TRUE(std::ranges::equal(v, std::vector<std::vector<int>>{{4, 5}}));
+    }
 }
 
 TEST(FixedVector, Erase_Empty)


### PR DESCRIPTION
Also rename `emplace_move_backward` to `uninitialized_relocate_backward`, introduce (forward) `uninitialized_relocate`, and complete the circle by resuming the use of `uninitialized_relocate` in `erase`.