### PR TITLE
Fixed unordered map clear

### DIFF
--- a/include/fixed_containers/fixed_index_based_storage.hpp
+++ b/include/fixed_containers/fixed_index_based_storage.hpp
@@ -7,6 +7,9 @@
 
 #include <array>
 #include <cstddef>
+#include <cstring>
+#include <memory>
+#include <type_traits>
 
 namespace fixed_containers
 {
@@ -72,6 +75,39 @@ public:
         array_unchecked_at(index).index = next_index();
         set_next_index(index);
         return index;
+    }
+
+    
+    // Set the freelist of `this` to match the freelist of `other`. This only makes sense if
+    // you will emplace valid values in the "full" spots (The ones not touched by this function). It
+    // explicitly makes _no guarantees_ about the contents of "full" slots in the destination.
+    // Warning: Assumes all the indices in `this` (destination) do not currently contain a
+    // value!
+    constexpr void set_freelist_state_from_other(const FixedIndexBasedPoolStorage& other)
+    {
+        if (!std::is_constant_evaluated())
+        {
+            // if we just memcpy the entire array, the freelist will match :)
+            // even if the values in the full slots aren't trivially copyable, the API for this
+            // function assumes they will never be accessed so it isn't UB
+            std::memcpy(reinterpret_cast<void*>(&this->IMPLEMENTATION_DETAIL_DO_NOT_USE_array_),
+                        reinterpret_cast<const void*>(&other.IMPLEMENTATION_DETAIL_DO_NOT_USE_array_),
+                        sizeof(this->IMPLEMENTATION_DETAIL_DO_NOT_USE_array_));
+        }
+        else
+        {
+            // in constexpr contexts, we instead need to traverse the freelist copying one value at
+            // a time, because `memcpy` is not constexpr and neither is any other naive copy of the
+            // underlying array
+            std::size_t cur_empty = other.next_index();
+            while (cur_empty != MAXIMUM_SIZE)
+            {
+                this->array_unchecked_at(cur_empty).index =
+                    other.array_unchecked_at(cur_empty).index;
+                cur_empty = other.array_unchecked_at(cur_empty).index;
+            }
+        }
+        this->set_next_index(other.next_index());
     }
 
 private:

--- a/test/fixed_map_test.cpp
+++ b/test/fixed_map_test.cpp
@@ -1511,6 +1511,130 @@ TEST(FixedMap, NonAssignable)
     }
 }
 
+TEST(FixedMap, ComplexNontrivialCopies)
+{
+    FixedMap<int, MockNonTrivialCopyAssignable, 30> map_1{};
+    for (int i = 0; i < 20; i++)
+    {
+        map_1.try_emplace(i + 100);
+    }
+
+    auto map_2{map_1};
+    for(const auto& pair : map_1)
+    {
+        EXPECT_TRUE(map_2.contains(pair.first));
+    }
+    EXPECT_EQ(map_2.size(), map_1.size());
+    map_2.clear();
+    for (int i = 0; i < 11; i++)
+    {
+        map_2.try_emplace(i + 100);
+    }
+    auto map_3{map_1};
+    for(const auto& pair : map_1)
+    {
+        EXPECT_TRUE(map_3.contains(pair.first));
+    }
+    EXPECT_EQ(map_3.size(), map_1.size());
+    map_3.clear();
+    for (int i = 0; i < 27; i++)
+    {
+        map_3.try_emplace(i + 100);
+    }
+    auto map_4{map_1};
+    for(const auto& pair : map_1)
+    {
+        EXPECT_TRUE(map_4.contains(pair.first));
+    }
+    EXPECT_EQ(map_4.size(), map_1.size());
+
+    map_1 = map_2;
+    for(const auto& pair : map_2)
+    {
+        EXPECT_TRUE(map_1.contains(pair.first));
+    }
+    map_1.clear();
+    map_1 = map_3;
+    for(const auto& pair : map_3)
+    {
+        EXPECT_TRUE(map_1.contains(pair.first));
+    }
+
+    // check that we can still add 3 elements (gets us to capacity)
+    map_1.try_emplace(127);
+    map_1.try_emplace(128);
+    map_1.try_emplace(129);
+    for (int i = 0; i < 30; i++)
+    {
+        EXPECT_TRUE(map_1.contains(i + 100));
+    }
+    EXPECT_EQ(map_1.size(), 30);
+
+    map_1.clear();
+    map_1 = map_4;
+    for(const auto& pair : map_4)
+    {
+        EXPECT_TRUE(map_1.contains(pair.first));
+    }
+    map_1.clear();
+}
+
+TEST(FixedUnorderedMap, ComplexNontrivialMoves)
+{
+    using FM = FixedMap<int, MockMoveableButNotCopyable, 30>;
+    FM map_1{};
+    FM map_1_orig{};
+    for (int i = 0; i < 20; i++)
+    {
+        map_1.try_emplace(i + 100);
+        map_1_orig.try_emplace(i + 100);
+    }
+
+    FM map_2{std::move(map_1)};
+    for(const auto& pair : map_1_orig)
+    {
+        EXPECT_TRUE(map_2.contains(pair.first));
+    }
+    FM map_2_orig{};
+    map_2.clear();
+    for (int i = 0; i < 11; i++)
+    {
+        map_2.try_emplace(i + 100);
+        map_2_orig.try_emplace(i + 100);
+    }
+    FM map_3{};
+    FM map_3_orig{};
+    map_3.clear();
+    for (int i = 0; i < 27; i++)
+    {
+        map_3.try_emplace(i + 100);
+        map_3_orig.try_emplace(i + 100);
+    }
+
+    map_1 = std::move(map_2);
+    for(const auto& pair : map_2_orig)
+    {
+        EXPECT_TRUE(map_1.contains(pair.first));
+    }
+    map_1.clear();
+    map_1 = std::move(map_3);
+    for(const auto& pair : map_3_orig)
+    {
+        EXPECT_TRUE(map_1.contains(pair.first));
+    }
+
+    // check that we can still add 3 elements (gets us to capacity)
+    map_1.try_emplace(127);
+    map_1.try_emplace(128);
+    map_1.try_emplace(129);
+    for (int i = 0; i < 30; i++)
+    {
+        EXPECT_TRUE(map_1.contains(i + 100));
+    }
+    EXPECT_EQ(map_1.size(), 30);
+    map_1.clear();
+}
+
 static constexpr int INT_VALUE_10 = 10;
 static constexpr int INT_VALUE_20 = 20;
 static constexpr int INT_VALUE_30 = 30;


### PR DESCRIPTION
I ran some benchmarks on different clear options:
1) just `try_emplace` into the new map
2) the process in this PR (including the scary-looking memcopy)
3) the process in this PR used for constexpr contexts (no memcopy)
<img width="649" alt="Screenshot 2024-06-19 at 7 50 30 PM" src="https://github.com/teslamotors/fixed-containers/assets/3848027/a20a30d6-6d79-4dda-a8fb-53bfaa04c7dd">

The above graph was created with a "fresh" map, starting empty and then pushing each element once. This means the linked list is in perfect order so we don't see the locality issues of using linked lists. Instead, I generated a "used" linked list by repeatedly deleting and replacing subsets of the array, yielding the following results:
<img width="649" alt="Screenshot 2024-06-19 at 7 51 04 PM" src="https://github.com/teslamotors/fixed-containers/assets/3848027/c15d5191-9b36-4e1f-809a-bfbc0938f714">
