### PR TITLE
Fix benchmark builds for bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,9 @@ http_archive(
     urls = ["https://github.com/google/benchmark/archive/bc946b919cac6f25a199a526da571638cfde109f.tar.gz"],
     strip_prefix = "benchmark-bc946b919cac6f25a199a526da571638cfde109f",
     sha256 = "997090899b61ff5a3f7f6714bc9147694d4f85266dbb93277ba9e6d60009a776",
+    patches = [
+        "//:patches/benchmark_as_system_include.patch",
+    ]
 )
 
 http_archive(

--- a/patches/benchmark_as_system_include.patch
+++ b/patches/benchmark_as_system_include.patch
@@ -1,0 +1,22 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index f7a1162..cd31663 100644
+--- BUILD.bazel
++++ BUILD.bazel
+@@ -87,7 +87,7 @@ cc_library(
+         "_LARGEFILE64_SOURCE",
+         "_LARGEFILE_SOURCE",
+     ],
+-    strip_include_prefix = "include",
++    includes = ["include"],
+     visibility = ["//visibility:public"],
+     deps = select({
+         ":perfcounters": ["@libpfm"],
+@@ -102,7 +102,7 @@ cc_library(
+         "include/benchmark/benchmark.h",
+         "include/benchmark/export.h",
+     ],
+-    strip_include_prefix = "include",
++    includes = ["include"],
+     visibility = ["//visibility:public"],
+     deps = [":benchmark"],
+ )


### PR DESCRIPTION
https://github.com/google/benchmark/pull/1803


```
In file included from test/fixed_map_perf_test.cpp:4:
bazel-out/k8-fastbuild/bin/external/com_google_benchmark/_virtual_includes/benchmark_main/benchmark/benchmark.h:1801:25: error: zero as null pointer constant [-Werror,-Wzero-as-null-pointer-constant]
 1801 |           memory_result(NULL),
      |                         ^~~~
      |                         nullptr
/usr/lib/llvm-17/lib/clang/17/include/stddef.h:84:18: note: expanded from macro 'NULL'
   84 | #    define NULL __null
      |                  ^
In file included from test/fixed_map_perf_test.cpp:4:
bazel-out/k8-fastbuild/bin/external/com_google_benchmark/_virtual_includes/benchmark_main/benchmark/benchmark.h:378:7: error: 'MemoryManager' has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit [-Werror,-Wweak-vtables]
  378 | class MemoryManager {
      |       ^
bazel-out/k8-fastbuild/bin/external/com_google_benchmark/_virtual_includes/benchmark_main/benchmark/benchmark.h:1437:7: error: 'Fixture' has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit [-Werror,-Wweak-vtables]
 1437 | class Fixture : public internal::Benchmark {
      |       ^
3 errors generated.

```