### PR TITLE
Special case make_fixed_*() for 0 parameters

### DIFF
--- a/include/fixed_containers/fixed_circular_deque.hpp
+++ b/include/fixed_containers/fixed_circular_deque.hpp
@@ -7,6 +7,7 @@
 #include "fixed_containers/source_location.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <initializer_list>
 #include <iterator>
@@ -506,6 +507,16 @@ template <typename T,
 {
     return {std::begin(list), std::end(list), loc};
 }
+template <typename T,
+          customize::SequenceContainerChecking CheckingType,
+          typename FixedCircularDequeType = FixedCircularDeque<T, 0, CheckingType>>
+[[nodiscard]] constexpr FixedCircularDequeType make_fixed_circular_deque(
+    const std::array<T, 0> /*list*/,
+    const std_transition::source_location& /*loc*/
+    = std_transition::source_location::current()) noexcept
+{
+    return {};
+}
 
 template <typename T, std::size_t MAXIMUM_SIZE>
 [[nodiscard]] constexpr auto make_fixed_circular_deque(
@@ -515,7 +526,18 @@ template <typename T, std::size_t MAXIMUM_SIZE>
 {
     using CheckingType = customize::SequenceContainerAbortChecking<T, MAXIMUM_SIZE>;
     using FixedCircularDequeType = FixedCircularDeque<T, MAXIMUM_SIZE, CheckingType>;
-    return make_fixed_deque<T, CheckingType, MAXIMUM_SIZE, FixedCircularDequeType>(list, loc);
+    return make_fixed_circular_deque<T, CheckingType, MAXIMUM_SIZE, FixedCircularDequeType>(list,
+                                                                                            loc);
+}
+template <typename T>
+[[nodiscard]] constexpr auto make_fixed_circular_deque(
+    const std::array<T, 0> list,
+    const std_transition::source_location& loc =
+        std_transition::source_location::current()) noexcept
+{
+    using CheckingType = customize::SequenceContainerAbortChecking<T, 0>;
+    using FixedCircularDequeType = FixedCircularDeque<T, 0, CheckingType>;
+    return make_fixed_circular_deque<T, CheckingType, FixedCircularDequeType>(list, loc);
 }
 
 }  // namespace fixed_containers

--- a/include/fixed_containers/fixed_deque.hpp
+++ b/include/fixed_containers/fixed_deque.hpp
@@ -1026,6 +1026,16 @@ template <typename T,
 {
     return {std::begin(list), std::end(list), loc};
 }
+template <typename T,
+          customize::SequenceContainerChecking CheckingType,
+          typename FixedDequeType = FixedDeque<T, 0, CheckingType>>
+[[nodiscard]] constexpr FixedDequeType make_fixed_deque(
+    const std::array<T, 0> /*list*/,
+    const std_transition::source_location& /*loc*/
+    = std_transition::source_location::current()) noexcept
+{
+    return {};
+}
 
 template <typename T, std::size_t MAXIMUM_SIZE>
 [[nodiscard]] constexpr auto make_fixed_deque(
@@ -1036,6 +1046,16 @@ template <typename T, std::size_t MAXIMUM_SIZE>
     using CheckingType = customize::SequenceContainerAbortChecking<T, MAXIMUM_SIZE>;
     using FixedDequeType = FixedDeque<T, MAXIMUM_SIZE, CheckingType>;
     return make_fixed_deque<T, CheckingType, MAXIMUM_SIZE, FixedDequeType>(list, loc);
+}
+template <typename T>
+[[nodiscard]] constexpr auto make_fixed_deque(
+    const std::array<T, 0> list,
+    const std_transition::source_location& loc =
+        std_transition::source_location::current()) noexcept
+{
+    using CheckingType = customize::SequenceContainerAbortChecking<T, 0>;
+    using FixedDequeType = FixedDeque<T, 0, CheckingType>;
+    return make_fixed_deque<T, CheckingType, FixedDequeType>(list, loc);
 }
 
 }  // namespace fixed_containers

--- a/include/fixed_containers/fixed_list.hpp
+++ b/include/fixed_containers/fixed_list.hpp
@@ -11,6 +11,7 @@
 #include "fixed_containers/source_location.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <initializer_list>
 #include <iterator>
@@ -652,6 +653,16 @@ template <typename T,
 {
     return {std::begin(list), std::end(list), loc};
 }
+template <typename T,
+          customize::SequenceContainerChecking CheckingType,
+          typename FixedListType = FixedList<T, 0, CheckingType>>
+[[nodiscard]] constexpr FixedListType make_fixed_list(
+    const std::array<T, 0> /*list*/,
+    const std_transition::source_location& /*loc*/
+    = std_transition::source_location::current()) noexcept
+{
+    return {};
+}
 
 template <typename T, std::size_t MAXIMUM_SIZE>
 [[nodiscard]] constexpr auto make_fixed_list(
@@ -662,6 +673,16 @@ template <typename T, std::size_t MAXIMUM_SIZE>
     using CheckingType = customize::SequenceContainerAbortChecking<T, MAXIMUM_SIZE>;
     using FixedListType = FixedList<T, MAXIMUM_SIZE, CheckingType>;
     return make_fixed_list<T, CheckingType, MAXIMUM_SIZE, FixedListType>(list, loc);
+}
+template <typename T>
+[[nodiscard]] constexpr auto make_fixed_list(
+    const std::array<T, 0> list,
+    const std_transition::source_location& loc =
+        std_transition::source_location::current()) noexcept
+{
+    using CheckingType = customize::SequenceContainerAbortChecking<T, 0>;
+    using FixedListType = FixedList<T, 0, CheckingType>;
+    return make_fixed_list<T, CheckingType, FixedListType>(list, loc);
 }
 
 }  // namespace fixed_containers

--- a/include/fixed_containers/fixed_map.hpp
+++ b/include/fixed_containers/fixed_map.hpp
@@ -12,6 +12,7 @@
 #include "fixed_containers/source_location.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <functional>
 
@@ -753,6 +754,23 @@ template <typename K,
 {
     return {std::begin(list), std::end(list), comparator, loc};
 }
+template <
+    typename K,
+    typename V,
+    typename Compare = std::less<K>,
+    fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
+        fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
+    template <typename, std::size_t> typename StorageTemplate = FixedIndexBasedPoolStorage,
+    customize::MapChecking<K> CheckingType,
+    typename FixedMapType = FixedMap<K, V, 0, Compare, COMPACTNESS, StorageTemplate, CheckingType>>
+[[nodiscard]] constexpr FixedMapType make_fixed_map(
+    const std::array<std::pair<K, V>, 0>& /*list*/,
+    const Compare& comparator = Compare{},
+    const std_transition::source_location& /*loc*/ =
+        std_transition::source_location::current()) noexcept
+{
+    return FixedMapType{comparator};
+}
 
 template <typename K,
           typename V,
@@ -777,6 +795,22 @@ template <typename K,
                           CheckingType,
                           MAXIMUM_SIZE,
                           FixedMapType>(list, comparator, loc);
+}
+template <typename K,
+          typename V,
+          typename Compare = std::less<K>,
+          fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
+              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
+          template <typename, std::size_t> typename StorageTemplate = FixedIndexBasedPoolStorage>
+[[nodiscard]] constexpr auto make_fixed_map(const std::array<std::pair<K, V>, 0>& list,
+                                            const Compare& comparator = Compare{},
+                                            const std_transition::source_location& loc =
+                                                std_transition::source_location::current()) noexcept
+{
+    using CheckingType = customize::MapAbortChecking<K, V, 0>;
+    using FixedMapType = FixedMap<K, V, 0, Compare, COMPACTNESS, StorageTemplate, CheckingType>;
+    return make_fixed_map<K, V, Compare, COMPACTNESS, StorageTemplate, CheckingType, FixedMapType>(
+        list, comparator, loc);
 }
 
 }  // namespace fixed_containers

--- a/include/fixed_containers/fixed_set.hpp
+++ b/include/fixed_containers/fixed_set.hpp
@@ -11,6 +11,7 @@
 #include "fixed_containers/source_location.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -491,6 +492,22 @@ template <typename K,
 {
     return {std::begin(list), std::end(list), comparator, loc};
 }
+template <
+    typename K,
+    typename Compare = std::less<K>,
+    fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
+        fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
+    template <typename, std::size_t> typename StorageTemplate = FixedIndexBasedPoolStorage,
+    customize::SetChecking<K> CheckingType,
+    typename FixedSetType = FixedSet<K, 0, Compare, COMPACTNESS, StorageTemplate, CheckingType>>
+[[nodiscard]] constexpr FixedSetType make_fixed_set(
+    const std::array<K, 0>& /*list*/,
+    const Compare& comparator = Compare{},
+    const std_transition::source_location& /*loc*/ =
+        std_transition::source_location::current()) noexcept
+{
+    return FixedSetType{comparator};
+}
 
 template <typename K,
           typename Compare = std::less<K>,
@@ -513,6 +530,21 @@ template <typename K,
                           CheckingType,
                           MAXIMUM_SIZE,
                           FixedSetType>(list, comparator, loc);
+}
+template <typename K,
+          typename Compare = std::less<K>,
+          fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness COMPACTNESS =
+              fixed_red_black_tree_detail::RedBlackTreeNodeColorCompactness::EMBEDDED_COLOR,
+          template <typename, std::size_t> typename StorageTemplate = FixedIndexBasedPoolStorage>
+[[nodiscard]] constexpr auto make_fixed_set(const std::array<K, 0>& list,
+                                            const Compare& comparator = Compare{},
+                                            const std_transition::source_location& loc =
+                                                std_transition::source_location::current()) noexcept
+{
+    using CheckingType = customize::SetAbortChecking<K, 0>;
+    using FixedSetType = FixedSet<K, 0, Compare, COMPACTNESS, StorageTemplate, CheckingType>;
+    return make_fixed_set<K, Compare, COMPACTNESS, StorageTemplate, CheckingType, FixedSetType>(
+        list, comparator, loc);
 }
 
 }  // namespace fixed_containers

--- a/include/fixed_containers/fixed_unordered_map.hpp
+++ b/include/fixed_containers/fixed_unordered_map.hpp
@@ -5,6 +5,8 @@
 #include "fixed_containers/map_checking.hpp"
 #include "fixed_containers/wyhash.hpp"
 
+#include <array>
+
 namespace fixed_containers
 {
 
@@ -86,6 +88,21 @@ template <
 {
     return {std::begin(list), std::end(list), hash, key_equal, loc};
 }
+template <typename K,
+          typename V,
+          class Hash = wyhash::hash<K>,
+          class KeyEqual = std::equal_to<K>,
+          customize::MapChecking<K> CheckingType,
+          typename FixedMapType = FixedUnorderedMap<K, V, 0, Hash, KeyEqual, 0, CheckingType>>
+[[nodiscard]] constexpr FixedMapType make_fixed_unordered_map(
+    const std::array<std::pair<K, V>, 0>& /*list*/,
+    const Hash& hash = Hash{},
+    const KeyEqual& key_equal = KeyEqual{},
+    const std_transition::source_location& /*loc*/ =
+        std_transition::source_location::current()) noexcept
+{
+    return FixedMapType{hash, key_equal};
+}
 
 template <
     typename K,
@@ -112,6 +129,19 @@ template <
                                     MAXIMUM_SIZE,
                                     BUCKET_COUNT,
                                     FixedMapType>(list, hash, key_equal, loc);
+}
+template <typename K, typename V, class Hash = wyhash::hash<K>, class KeyEqual = std::equal_to<K>>
+[[nodiscard]] constexpr auto make_fixed_unordered_map(
+    const std::array<std::pair<K, V>, 0> list,
+    const Hash& hash = Hash{},
+    const KeyEqual& key_equal = KeyEqual{},
+    const std_transition::source_location& loc =
+        std_transition::source_location::current()) noexcept
+{
+    using CheckingType = customize::MapAbortChecking<K, V, 0>;
+    using FixedMapType = FixedUnorderedMap<K, V, 0, Hash, KeyEqual, 0, CheckingType>;
+    return make_fixed_unordered_map<K, V, Hash, KeyEqual, CheckingType, FixedMapType>(
+        list, hash, key_equal, loc);
 }
 
 }  // namespace fixed_containers

--- a/include/fixed_containers/fixed_unordered_set.hpp
+++ b/include/fixed_containers/fixed_unordered_set.hpp
@@ -6,6 +6,8 @@
 #include "fixed_containers/set_checking.hpp"
 #include "fixed_containers/wyhash.hpp"
 
+#include <array>
+
 namespace fixed_containers
 {
 
@@ -83,6 +85,20 @@ template <
 {
     return {std::begin(list), std::end(list), hash, key_equal, loc};
 }
+template <typename K,
+          class Hash = wyhash::hash<K>,
+          class KeyEqual = std::equal_to<K>,
+          customize::SetChecking<K> CheckingType,
+          typename FixedSetType = FixedUnorderedSet<K, 0, Hash, KeyEqual, 0, CheckingType>>
+[[nodiscard]] constexpr FixedSetType make_fixed_unordered_set(
+    const std::array<K, 0>& /*list*/,
+    const Hash& hash = Hash{},
+    const KeyEqual& key_equal = KeyEqual{},
+    const std_transition::source_location& /*loc*/ =
+        std_transition::source_location::current()) noexcept
+{
+    return {hash, key_equal};
+}
 
 template <
     typename K,
@@ -107,6 +123,19 @@ template <
                                     MAXIMUM_SIZE,
                                     BUCKET_COUNT,
                                     FixedSetType>(list, hash, key_equal, loc);
+}
+template <typename K, class Hash = wyhash::hash<K>, class KeyEqual = std::equal_to<K>>
+[[nodiscard]] constexpr auto make_fixed_unordered_set(
+    const std::array<K, 0>& list,
+    const Hash& hash = Hash{},
+    const KeyEqual& key_equal = KeyEqual{},
+    const std_transition::source_location& loc =
+        std_transition::source_location::current()) noexcept
+{
+    using CheckingType = customize::SetAbortChecking<K, 0>;
+    using FixedSetType = FixedUnorderedSet<K, 0, Hash, KeyEqual, 0, CheckingType>;
+    return make_fixed_unordered_set<K, Hash, KeyEqual, CheckingType, FixedSetType>(
+        list, hash, key_equal, loc);
 }
 
 }  // namespace fixed_containers

--- a/include/fixed_containers/fixed_vector.hpp
+++ b/include/fixed_containers/fixed_vector.hpp
@@ -1019,6 +1019,16 @@ template <typename T,
 {
     return {std::begin(list), std::end(list), loc};
 }
+template <typename T,
+          customize::SequenceContainerChecking CheckingType,
+          typename FixedVectorType = FixedVector<T, 0, CheckingType>>
+[[nodiscard]] constexpr FixedVectorType make_fixed_vector(
+    const std::array<T, 0> /*list*/,
+    const std_transition::source_location& /*loc*/
+    = std_transition::source_location::current()) noexcept
+{
+    return {};
+}
 
 template <typename T, std::size_t MAXIMUM_SIZE>
 [[nodiscard]] constexpr auto make_fixed_vector(
@@ -1029,6 +1039,16 @@ template <typename T, std::size_t MAXIMUM_SIZE>
     using CheckingType = customize::SequenceContainerAbortChecking<T, MAXIMUM_SIZE>;
     using FixedVectorType = FixedVector<T, MAXIMUM_SIZE, CheckingType>;
     return make_fixed_vector<T, CheckingType, MAXIMUM_SIZE, FixedVectorType>(list, loc);
+}
+template <typename T>
+[[nodiscard]] constexpr auto make_fixed_vector(
+    const std::array<T, 0> list,
+    const std_transition::source_location& loc =
+        std_transition::source_location::current()) noexcept
+{
+    using CheckingType = customize::SequenceContainerAbortChecking<T, 0>;
+    using FixedVectorType = FixedVector<T, 0, CheckingType>;
+    return make_fixed_vector<T, CheckingType, FixedVectorType>(list, loc);
 }
 
 }  // namespace fixed_containers

--- a/test/fixed_circular_deque_test.cpp
+++ b/test/fixed_circular_deque_test.cpp
@@ -134,9 +134,15 @@ TEST(FixedCircularDeque, CountConstructor_ExceedsCapacity)
 
 TEST(FixedCircularDeque, MaxSizeDeduction)
 {
-    constexpr auto v1 = make_fixed_circular_deque({10, 11, 12, 13, 14});
-    static_assert(v1.max_size() == 5);
-    static_assert(std::ranges::equal(v1, std::array{10, 11, 12, 13, 14}));
+    {
+        constexpr auto v1 = make_fixed_circular_deque({10, 11, 12, 13, 14});
+        static_assert(v1.max_size() == 5);
+        static_assert(std::ranges::equal(v1, std::array{10, 11, 12, 13, 14}));
+    }
+    {
+        constexpr auto v1 = make_fixed_circular_deque<int>({});
+        static_assert(v1.max_size() == 0);
+    }
 }
 
 TEST(FixedCircularDeque, IteratorConstructor)

--- a/test/fixed_deque_test.cpp
+++ b/test/fixed_deque_test.cpp
@@ -129,9 +129,15 @@ TEST(FixedDeque, CountConstructor_ExceedsCapacity)
 
 TEST(FixedDeque, MaxSizeDeduction)
 {
-    constexpr auto v1 = make_fixed_deque({10, 11, 12, 13, 14});
-    static_assert(v1.max_size() == 5);
-    static_assert(std::ranges::equal(v1, std::array{10, 11, 12, 13, 14}));
+    {
+        constexpr auto v1 = make_fixed_deque({10, 11, 12, 13, 14});
+        static_assert(v1.max_size() == 5);
+        static_assert(std::ranges::equal(v1, std::array{10, 11, 12, 13, 14}));
+    }
+    {
+        constexpr auto v1 = make_fixed_deque<int>({});
+        static_assert(v1.max_size() == 0);
+    }
 }
 
 TEST(FixedDeque, IteratorConstructor)

--- a/test/fixed_list_test.cpp
+++ b/test/fixed_list_test.cpp
@@ -265,9 +265,15 @@ TEST(FixedList, MockTriviallyCopyableButNotCopyableOrMoveable)
 
 TEST(FixedList, MaxSizeDeduction)
 {
-    constexpr auto v1 = make_fixed_list({10, 11, 12, 13, 14});
-    static_assert(v1.max_size() == 5);
-    static_assert(std::ranges::equal(v1, std::array{10, 11, 12, 13, 14}));
+    {
+        constexpr auto v1 = make_fixed_list({10, 11, 12, 13, 14});
+        static_assert(v1.max_size() == 5);
+        static_assert(std::ranges::equal(v1, std::array{10, 11, 12, 13, 14}));
+    }
+    {
+        constexpr auto v1 = make_fixed_list<int>({});
+        static_assert(v1.max_size() == 0);
+    }
 }
 
 TEST(FixedList, CountConstructor)

--- a/test/fixed_map_test.cpp
+++ b/test/fixed_map_test.cpp
@@ -141,12 +141,19 @@ TEST(FixedMap, OperatorBracket_Constexpr)
 
 TEST(FixedMap, MaxSizeDeduction)
 {
-    constexpr auto s1 = make_fixed_map({std::pair{30, 30}, std::pair{31, 54}});
-    static_assert(s1.size() == 2);
-    static_assert(s1.max_size() == 2);
-    static_assert(s1.contains(30));
-    static_assert(s1.contains(31));
-    static_assert(!s1.contains(32));
+    {
+        constexpr auto s1 = make_fixed_map({std::pair{30, 30}, std::pair{31, 54}});
+        static_assert(s1.size() == 2);
+        static_assert(s1.max_size() == 2);
+        static_assert(s1.contains(30));
+        static_assert(s1.contains(31));
+        static_assert(!s1.contains(32));
+    }
+    {
+        constexpr auto s1 = make_fixed_map<int, int>({});
+        static_assert(s1.size() == 0);
+        static_assert(s1.max_size() == 0);
+    }
 }
 
 TEST(FixedMap, OperatorBracket_NonConstexpr)

--- a/test/fixed_set_test.cpp
+++ b/test/fixed_set_test.cpp
@@ -211,12 +211,19 @@ TEST(FixedSet, EmptySizeFull)
 
 TEST(FixedSet, MaxSizeDeduction)
 {
-    constexpr auto s1 = make_fixed_set({30, 31});
-    static_assert(s1.size() == 2);
-    static_assert(s1.max_size() == 2);
-    static_assert(s1.contains(30));
-    static_assert(s1.contains(31));
-    static_assert(!s1.contains(32));
+    {
+        constexpr auto s1 = make_fixed_set({30, 31});
+        static_assert(s1.size() == 2);
+        static_assert(s1.max_size() == 2);
+        static_assert(s1.contains(30));
+        static_assert(s1.contains(31));
+        static_assert(!s1.contains(32));
+    }
+    {
+        constexpr auto s1 = make_fixed_set<int>({});
+        static_assert(s1.size() == 0);
+        static_assert(s1.max_size() == 0);
+    }
 }
 
 TEST(FixedSet, Insert)

--- a/test/fixed_unordered_map_test.cpp
+++ b/test/fixed_unordered_map_test.cpp
@@ -139,12 +139,19 @@ TEST(FixedUnorderedMap, OperatorBracket_Constexpr)
 
 TEST(FixedUnorderedMap, MaxSizeDeduction)
 {
-    constexpr auto s1 = make_fixed_unordered_map({std::pair{30, 30}, std::pair{31, 54}});
-    static_assert(s1.size() == 2);
-    static_assert(s1.max_size() == 2);
-    static_assert(s1.contains(30));
-    static_assert(s1.contains(31));
-    static_assert(!s1.contains(32));
+    {
+        constexpr auto s1 = make_fixed_unordered_map({std::pair{30, 30}, std::pair{31, 54}});
+        static_assert(s1.size() == 2);
+        static_assert(s1.max_size() == 2);
+        static_assert(s1.contains(30));
+        static_assert(s1.contains(31));
+        static_assert(!s1.contains(32));
+    }
+    {
+        constexpr auto s1 = make_fixed_unordered_map<int, int>({});
+        static_assert(s1.size() == 0);
+        static_assert(s1.max_size() == 0);
+    }
 }
 
 TEST(FixedUnorderedMap, OperatorBracket_NonConstexpr)

--- a/test/fixed_unordered_set_test.cpp
+++ b/test/fixed_unordered_set_test.cpp
@@ -141,12 +141,19 @@ TEST(FixedUnorderedSet, EmptySizeFull)
 
 TEST(FixedUnorderedSet, MaxSizeDeduction)
 {
-    constexpr auto s1 = make_fixed_unordered_set({30, 31});
-    static_assert(s1.size() == 2);
-    static_assert(s1.max_size() == 2);
-    static_assert(s1.contains(30));
-    static_assert(s1.contains(31));
-    static_assert(!s1.contains(32));
+    {
+        constexpr auto s1 = make_fixed_unordered_set({30, 31});
+        static_assert(s1.size() == 2);
+        static_assert(s1.max_size() == 2);
+        static_assert(s1.contains(30));
+        static_assert(s1.contains(31));
+        static_assert(!s1.contains(32));
+    }
+    {
+        constexpr auto s1 = make_fixed_unordered_set<int>({});
+        static_assert(s1.size() == 0);
+        static_assert(s1.max_size() == 0);
+    }
 }
 
 TEST(FixedUnorderedSet, Insert)

--- a/test/fixed_vector_test.cpp
+++ b/test/fixed_vector_test.cpp
@@ -392,9 +392,15 @@ TEST(FixedVector, Builder_MultipleOuts)
 
 TEST(FixedVector, MaxSizeDeduction)
 {
-    constexpr auto v1 = make_fixed_vector({10, 11, 12, 13, 14});
-    static_assert(v1.max_size() == 5);
-    static_assert(std::ranges::equal(v1, std::array{10, 11, 12, 13, 14}));
+    {
+        constexpr auto v1 = make_fixed_vector({10, 11, 12, 13, 14});
+        static_assert(v1.max_size() == 5);
+        static_assert(std::ranges::equal(v1, std::array{10, 11, 12, 13, 14}));
+    }
+    {
+        constexpr auto v1 = make_fixed_vector<int>({});
+        static_assert(v1.max_size() == 0);
+    }
 }
 
 TEST(FixedVector, CountConstructor)


### PR DESCRIPTION
This is to allow users to specify such containers without needing to special-case on the client-side. As an exmaple, this can happen with conditionally populated entries from macros or codegen