### PR TITLE
[RandomAccessIterator] Fix reference to non-existent member

### DIFF
--- a/include/fixed_containers/random_access_iterator.hpp
+++ b/include/fixed_containers/random_access_iterator.hpp
@@ -161,7 +161,7 @@ public:
 
     friend constexpr Self operator+(difference_type n, const Self& other)
     {
-        return Self(std::next(other.iterator_, n));
+        return Self{std::next(other, n)};
     }
 
     constexpr Self& operator-=(difference_type n)

--- a/include/fixed_containers/random_access_iterator_transformer.hpp
+++ b/include/fixed_containers/random_access_iterator_transformer.hpp
@@ -138,7 +138,7 @@ public:
 
     friend constexpr Self operator+(difference_type off, const Self& other)
     {
-        return Self(std::next(other.iterator_, off), other.unary_function_);
+        return Self{std::next(other.iterator_, off), other.unary_function_};
     }
 
     constexpr Self& operator-=(difference_type off)

--- a/test/fixed_circular_deque_test.cpp
+++ b/test/fixed_circular_deque_test.cpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <deque>
 #include <initializer_list>
+#include <iterator>
 #include <limits>
 #include <type_traits>
 
@@ -30,6 +31,9 @@ static_assert(TriviallyCopyable<CircularDequeType>);
 static_assert(NotTrivial<CircularDequeType>);
 static_assert(StandardLayout<CircularDequeType>);
 static_assert(IsStructuralType<CircularDequeType>);
+
+static_assert(std::random_access_iterator<CircularDequeType::iterator>);
+static_assert(std::random_access_iterator<CircularDequeType::const_iterator>);
 }  // namespace trivially_copyable_vector
 
 struct ComplexStruct
@@ -912,6 +916,9 @@ TEST(FixedCircularDeque, TrivialIterators)
             static_assert(*std::prev(v1.end(), 1) == 99);
             static_assert(*std::prev(v1.end(), 2) == 88);
             static_assert(*std::prev(v1.end(), 3) == 77);
+
+            static_assert(*(1 + v1.begin()) == 88);
+            static_assert(*(2 + v1.begin()) == 99);
         }
 
         {
@@ -1032,6 +1039,9 @@ TEST(FixedCircularDeque, ReverseIterators)
             static_assert(*std::prev(v1.rend(), 1) == 77);
             static_assert(*std::prev(v1.rend(), 2) == 88);
             static_assert(*std::prev(v1.rend(), 3) == 99);
+
+            static_assert(*(1 + v1.begin()) == 88);
+            static_assert(*(2 + v1.begin()) == 99);
         }
 
         {

--- a/test/fixed_deque_test.cpp
+++ b/test/fixed_deque_test.cpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <deque>
 #include <initializer_list>
+#include <iterator>
 #include <limits>
 #include <type_traits>
 #include <utility>
@@ -31,6 +32,10 @@ static_assert(TriviallyCopyable<DequeType>);
 static_assert(NotTrivial<DequeType>);
 static_assert(StandardLayout<DequeType>);
 static_assert(IsStructuralType<DequeType>);
+
+static_assert(std::random_access_iterator<DequeType::iterator>);
+static_assert(std::random_access_iterator<DequeType::const_iterator>);
+
 }  // namespace trivially_copyable_deque
 
 struct ComplexStruct
@@ -864,6 +869,9 @@ TEST(FixedDeque, TrivialIterators)
             static_assert(*std::prev(v1.end(), 1) == 99);
             static_assert(*std::prev(v1.end(), 2) == 88);
             static_assert(*std::prev(v1.end(), 3) == 77);
+
+            static_assert(*(1 + v1.begin()) == 88);
+            static_assert(*(2 + v1.begin()) == 99);
         }
 
         {
@@ -984,6 +992,9 @@ TEST(FixedDeque, ReverseIterators)
             static_assert(*std::prev(v1.rend(), 1) == 77);
             static_assert(*std::prev(v1.rend(), 2) == 88);
             static_assert(*std::prev(v1.rend(), 3) == 99);
+
+            static_assert(*(1 + v1.rbegin()) == 88);
+            static_assert(*(2 + v1.rbegin()) == 77);
         }
 
         {

--- a/test/fixed_string_test.cpp
+++ b/test/fixed_string_test.cpp
@@ -28,6 +28,9 @@ static_assert(NotTrivial<FixedStringType>);
 static_assert(StandardLayout<FixedStringType>);
 static_assert(IsStructuralType<FixedStringType>);
 
+static_assert(std::contiguous_iterator<FixedStringType::iterator>);
+static_assert(std::contiguous_iterator<FixedStringType::const_iterator>);
+
 void const_span_ref(const std::span<char>&) {}
 void const_span_of_const_ref(const std::span<const char>&) {}
 
@@ -483,6 +486,9 @@ TEST(FixedString, TrivialIterators)
         static_assert(*std::prev(v1.end(), 1) == '9');
         static_assert(*std::prev(v1.end(), 2) == '8');
         static_assert(*std::prev(v1.end(), 3) == '7');
+
+        static_assert(*(1 + v1.begin()) == '8');
+        static_assert(*(2 + v1.begin()) == '9');
     }
 
     {
@@ -551,6 +557,9 @@ TEST(FixedString, ReverseIterators)
         static_assert(*std::prev(v1.rend(), 1) == '7');
         static_assert(*std::prev(v1.rend(), 2) == '8');
         static_assert(*std::prev(v1.rend(), 3) == '9');
+
+        static_assert(*(1 + v1.begin()) == '8');
+        static_assert(*(2 + v1.begin()) == '9');
     }
 
     {

--- a/test/fixed_vector_test.cpp
+++ b/test/fixed_vector_test.cpp
@@ -898,6 +898,9 @@ TEST(FixedVector, TrivialIterators)
         static_assert(*std::prev(v1.end(), 1) == 99);
         static_assert(*std::prev(v1.end(), 2) == 88);
         static_assert(*std::prev(v1.end(), 3) == 77);
+
+        static_assert(*(1 + v1.begin()) == 88);
+        static_assert(*(2 + v1.begin()) == 99);
     }
 
     {
@@ -1007,6 +1010,9 @@ TEST(FixedVector, ReverseIterators)
         static_assert(*std::prev(v1.rend(), 1) == 77);
         static_assert(*std::prev(v1.rend(), 2) == 88);
         static_assert(*std::prev(v1.rend(), 3) == 99);
+
+        static_assert(*(1 + v1.begin()) == 88);
+        static_assert(*(2 + v1.begin()) == 99);
     }
 
     {


### PR DESCRIPTION
Exposed by https://github.com/teslamotors/fixed-containers/issues/128

This was previously building without issue due to two-phase lookup and the function never being called. New units tests will instantiate this function.

```C++
template <class T>
struct MockTemplate
{
    int foo(const MockTemplate<T>& input) const { return input.variable_that_does_not_exist; }
};

int main()
{
    MockTemplate<int> it{};
    (void)it;
    // it.foo(it);
}

```