### PR TITLE
[OptionalReference] introduce OptionalReference(std::nullopt_t)

### DIFF
--- a/include/fixed_containers/optional_reference.hpp
+++ b/include/fixed_containers/optional_reference.hpp
@@ -29,11 +29,20 @@ private:
 
 public:
     // Needed for structural type
-    BackingType IMPLEMENTION_DETAIL_DO_NOT_USE_underlying_val_ = nullptr;
+    BackingType IMPLEMENTION_DETAIL_DO_NOT_USE_underlying_val_;
 
 public:
-    // ctors are explicit to highlight the fact we are creating long living reference
-    constexpr OptionalReference() = default;
+    constexpr OptionalReference() noexcept
+      : IMPLEMENTION_DETAIL_DO_NOT_USE_underlying_val_(nullptr)
+    {
+    }
+
+    constexpr OptionalReference(std::nullopt_t) noexcept
+      : OptionalReference()
+    {
+    }
+
+    // ctors is explicit to highlight the fact we are creating long living reference
     explicit constexpr OptionalReference(T& val) noexcept
       : IMPLEMENTION_DETAIL_DO_NOT_USE_underlying_val_(std::addressof(val))
     {

--- a/test/optional_reference_test.cpp
+++ b/test/optional_reference_test.cpp
@@ -325,4 +325,10 @@ TEST(OptionalReference, RValueCtor)
     // OptionalReference<const int>(10); // fails to compile, intentional
 }
 
+TEST(OptionalReference, NulloptCtor)
+{
+    constexpr OptionalReference<int> rome(std::nullopt);
+    static_assert(!rome.has_value());
+}
+
 }  // namespace fixed_containers


### PR DESCRIPTION
This ctor exists for std::optional