### PR TITLE
[clang-tidy] Ignore identifier `_` which expresses an unused variable

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -98,3 +98,4 @@ CheckOptions:
   - { key: readability-identifier-naming.GlobalConstantCase,          value: UPPER_CASE   }
   - { key: readability-identifier-naming.MemberConstantCase,          value: UPPER_CASE   }
   - { key: readability-identifier-naming.StaticConstantCase,          value: UPPER_CASE   }
+  - { key: readability-identifier-length.IgnoredVariableNames,        value: "^[_]$"      }

--- a/test/fixed_map_perf_test.cpp
+++ b/test/fixed_map_perf_test.cpp
@@ -74,7 +74,7 @@ void benchmark_map_lookup(benchmark::State& state)
         instance.try_emplace(static_cast<KeyType>(i));
     }
 
-    for (auto unused : state)
+    for (auto _ : state)
     {
         auto& entry = instance.at(7);
         benchmark::DoNotOptimize(entry);


### PR DESCRIPTION
This is auto-ignored for structured bindings, but not for loops. A frequent use of this is for perf tests with google benchmark