### PR TITLE
Allow error handling from StructView::add_path

### DIFF
--- a/include/fixed_containers/struct_view.hpp
+++ b/include/fixed_containers/struct_view.hpp
@@ -568,7 +568,7 @@ public:
     }
 
     template <typename S>
-    bool add_path(S&& instance, const PathNameChain& path)
+    bool try_add_path(S&& instance, const PathNameChain& path)
     {
         auto path_properties_map = extract_path_properties_of_filtered<S, 1, 1>(
             std::forward<S>(instance), std::optional<FixedSet<PathNameChain, 1>>({path}));
@@ -584,14 +584,14 @@ public:
     }
 
     template <typename S>
-    bool add_path(const PathNameChain& path)
+    bool try_add_path(const PathNameChain& path)
     {
         S instance{};
-        return add_path(instance, path);
+        return try_add_path(instance, path);
     }
 
     template <typename S, typename PathSet>
-    bool add_paths(S&& instance, const PathSet& paths)
+    bool try_add_paths(S&& instance, const PathSet& paths)
     {
         auto path_properties_map =
             extract_path_properties_of_filtered(std::forward<S>(instance), paths);
@@ -609,10 +609,10 @@ public:
     }
 
     template <typename S, typename PathSet>
-    bool add_paths(const PathSet& paths)
+    bool try_add_paths(const PathSet& paths)
     {
         S instance{};
-        return add_paths(instance, paths);
+        return try_add_paths(instance, paths);
     }
 
     [[nodiscard]] PathProperties at(const PathNameChain& path) const

--- a/test/struct_view_test.cpp
+++ b/test/struct_view_test.cpp
@@ -49,6 +49,7 @@ struct FlatSuperStruct1
     std::int32_t ignore2{};
     std::int32_t retain2{};
     std::int16_t ignore3{};
+    unsigned char bigbuf[1024*1024];
 };
 
 struct FlatSubStruct1
@@ -118,7 +119,7 @@ TEST(StructView, ExtractPathPropertiesOfFlat)
 TEST(StructView, StructViewFlat)
 {
     auto super_struct_view = StructView();
-    bool success = super_struct_view.add_path<FlatSuperStruct1>(path_from_string("retain1"));
+    bool success = super_struct_view.try_add_path<FlatSuperStruct1>(path_from_string("retain1"));
     EXPECT_TRUE(success);
 }
 

--- a/test/struct_view_test.cpp
+++ b/test/struct_view_test.cpp
@@ -118,7 +118,8 @@ TEST(StructView, ExtractPathPropertiesOfFlat)
 TEST(StructView, StructViewFlat)
 {
     auto super_struct_view = StructView();
-    super_struct_view.add_path<FlatSuperStruct1>(path_from_string("retain1"));
+    bool success = super_struct_view.add_path<FlatSuperStruct1>(path_from_string("retain1"));
+    EXPECT_TRUE(success);
 }
 
 TEST(StructView, SubStructViewOfFlat)


### PR DESCRIPTION
If the path does not resolve to reflected field data, return `false` from `add_path` so that callers can properly handle error conditions.