### PR TITLE
Add explicit deduction guide for Overloaded

### DIFF
--- a/include/fixed_containers/concepts.hpp
+++ b/include/fixed_containers/concepts.hpp
@@ -159,6 +159,8 @@ struct Overloaded : Ts...
 {
     using Ts::operator()...;
 };
+template <class... Ts>
+Overloaded(Ts...) -> Overloaded<Ts...>;
 
 // a "void-like" type, but without the hassle
 // e.g. EmptyValue& is a valid type


### PR DESCRIPTION
It is not needed as of C++20, but older clang versions are failing. Fixes build for clang <=16