### PR TITLE
[vcpkg] Temporarily pin magic_enum to 0.9.6 to fix CI

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,8 +2,21 @@
   "name": "fixed-containers",
   "version-string": "0.0.0",
   "dependencies": [
-    "magic-enum",
-    "benchmark",
-    "gtest"
-  ]
+    {
+      "name": "magic-enum"
+    },
+    {
+      "name": "benchmark"
+    },
+    {
+      "name": "gtest"
+    }
+  ],
+  "overrides": [
+    {
+      "name": "magic-enum",
+      "version": "0.9.6#1"
+    }
+  ],
+  "builtin-baseline": "a345bbdc68cdfda65603e24413b21afb28f110fb"
 }


### PR DESCRIPTION
0.9.7 changes <magic_enum.hpp> to <magic_enum/magic_enum.hpp>