### PR TITLE
[OptionalReference] Add pointer constructor

### DIFF
--- a/include/fixed_containers/optional_reference.hpp
+++ b/include/fixed_containers/optional_reference.hpp
@@ -44,6 +44,16 @@ public:
     }
 
     // ctors is explicit to highlight the fact we are creating long living reference
+    explicit constexpr OptionalReference(pointer ptr) noexcept
+      : IMPLEMENTION_DETAIL_DO_NOT_USE_underlying_val_{ptr}
+    {
+    }
+
+    explicit constexpr OptionalReference(const std::unique_ptr<T>& ptr)
+      : OptionalReference(ptr.get())
+    {
+    }
+
     explicit constexpr OptionalReference(T& val) noexcept
       : IMPLEMENTION_DETAIL_DO_NOT_USE_underlying_val_(std::addressof(val))
     {

--- a/test/optional_reference_test.cpp
+++ b/test/optional_reference_test.cpp
@@ -374,4 +374,24 @@ TEST(OptionalReference, NulloptCtor)
     static_assert(!VAL1.has_value());
 }
 
+TEST(OptionalReference, PtrCtor)
+{
+    int i = 42;
+    int* iptr = &i;
+    OptionalReference<int> iref{iptr};
+    ASSERT_TRUE(iref.has_value());
+
+    int* emptyptr = nullptr;
+    OptionalReference<int> emptyref{emptyptr};
+    ASSERT_FALSE(emptyref.has_value());
+
+    std::unique_ptr<int> uniqptr = std::make_unique<int>(69);
+    OptionalReference<int> uniqref{uniqptr};
+    ASSERT_TRUE(uniqref.has_value());
+
+    std::unique_ptr<int> uniqnull{};
+    OptionalReference<int> uniqnullref{uniqnull};
+    ASSERT_FALSE(uniqnullref.has_value());
+}
+
 }  // namespace fixed_containers


### PR DESCRIPTION
This adds a constructor to `OptionalReference` that allows creating references from pointer types.