### PR TITLE
[Sets] Add unit tests for find() and fix uncovered issues

### DIFF
--- a/include/fixed_containers/enum_set.hpp
+++ b/include/fixed_containers/enum_set.hpp
@@ -351,6 +351,17 @@ public:
         return 1;
     }
 
+    [[nodiscard]] constexpr const_iterator find(const K& key) const noexcept
+    {
+        const std::size_t ordinal = EnumAdapterType::ordinal(key);
+        if (!this->contains_at(ordinal))
+        {
+            return this->cend();
+        }
+
+        return create_const_iterator(ordinal);
+    }
+
     [[nodiscard]] constexpr bool contains(const K& key) const noexcept
     {
         return contains_at(EnumAdapterType::ordinal(key));

--- a/include/fixed_containers/fixed_set_adapter.hpp
+++ b/include/fixed_containers/fixed_set_adapter.hpp
@@ -320,7 +320,7 @@ private:
         return create_const_iterator(index);
     }
 
-    constexpr iterator create_const_iterator(const TableIndex& start_index) noexcept
+    constexpr iterator create_const_iterator(const TableIndex& start_index) const noexcept
     {
         return iterator{
             ReferenceProvider{std::addressof(table()), table().iterated_index_from(start_index)}};

--- a/test/enum_set_test.cpp
+++ b/test/enum_set_test.cpp
@@ -211,6 +211,17 @@ TEST(EnumSet, InitializerConstructor)
     static_assert(VAL2.size() == 1);
 }
 
+TEST(EnumSet, Find)
+{
+    constexpr EnumSet<TestEnum1> VAL1{TestEnum1::TWO, TestEnum1::FOUR};
+    static_assert(VAL1.size() == 2);
+
+    static_assert(VAL1.find(TestEnum1::ONE) == VAL1.cend());
+    static_assert(VAL1.find(TestEnum1::TWO) != VAL1.cend());
+    static_assert(VAL1.find(TestEnum1::THREE) == VAL1.cend());
+    static_assert(VAL1.find(TestEnum1::FOUR) != VAL1.cend());
+}
+
 TEST(EnumSet, Contains)
 {
     constexpr EnumSet<TestEnum1> VAL1{TestEnum1::TWO, TestEnum1::FOUR};

--- a/test/fixed_set_test.cpp
+++ b/test/fixed_set_test.cpp
@@ -78,6 +78,17 @@ TEST(FixedSet, Initializer)
     static_assert(VAL2.size() == 1);
 }
 
+TEST(FixedSet, Find)
+{
+    constexpr FixedSet<int, 10> VAL1{2, 4};
+    static_assert(VAL1.size() == 2);
+
+    static_assert(VAL1.find(1) == VAL1.cend());
+    static_assert(VAL1.find(2) != VAL1.cend());
+    static_assert(VAL1.find(3) == VAL1.cend());
+    static_assert(VAL1.find(4) != VAL1.cend());
+}
+
 TEST(FixedSet, FindTransparentComparator)
 {
     constexpr FixedSet<MockAComparableToB, 3, std::less<>> VAL{};

--- a/test/fixed_unordered_set_test.cpp
+++ b/test/fixed_unordered_set_test.cpp
@@ -78,6 +78,17 @@ TEST(FixedUnorderedSet, Initializer)
     static_assert(VAL2.size() == 1);
 }
 
+TEST(FixedUnorderedSet, Find)
+{
+    constexpr FixedUnorderedSet<int, 10> VAL1{2, 4};
+    static_assert(VAL1.size() == 2);
+
+    static_assert(VAL1.find(1) == VAL1.cend());
+    static_assert(VAL1.find(2) != VAL1.cend());
+    static_assert(VAL1.find(3) == VAL1.cend());
+    static_assert(VAL1.find(4) != VAL1.cend());
+}
+
 // TEST(FixedUnorderedSet, Find_TransparentComparator)
 // {
 //     constexpr FixedUnorderedSet<MockAComparableToB, 3, std::less<>> var{};


### PR DESCRIPTION
- Missing const in FixedSetAdapter
- Missing find() implementation in `EnumSet