### PR TITLE
Fix -Wunsafe-buffer-usage-in-libc-call issues

### DIFF
--- a/include/fixed_containers/fixed_index_based_storage.hpp
+++ b/include/fixed_containers/fixed_index_based_storage.hpp
@@ -86,13 +86,20 @@ public:
     {
         if (!std::is_constant_evaluated())
         {
-            // if we just memcpy the entire array, the freelist will match :)
-            // even if the values in the full slots aren't trivially copyable, the API for this
-            // function assumes they will never be accessed so it isn't UB
+// if we just memcpy the entire array, the freelist will match :)
+// even if the values in the full slots aren't trivially copyable, the API for this
+// function assumes they will never be accessed so it isn't UB
+#if defined(__clang__) && __clang_major__ >= 20
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage-in-libc-call"
+#endif
             std::memcpy(
                 reinterpret_cast<void*>(&this->IMPLEMENTATION_DETAIL_DO_NOT_USE_array_),
                 reinterpret_cast<const void*>(&other.IMPLEMENTATION_DETAIL_DO_NOT_USE_array_),
                 sizeof(this->IMPLEMENTATION_DETAIL_DO_NOT_USE_array_));
+#if defined(__clang__) && __clang_major__ >= 20
+#pragma clang diagnostic pop
+#endif
         }
         else
         {

--- a/include/fixed_containers/wyhash.hpp
+++ b/include/fixed_containers/wyhash.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <array>
+#include <bit>
 #include <cstdint>
-#include <cstring>
 #include <functional>
 #include <iterator>
 #include <memory>
@@ -64,16 +64,16 @@ constexpr void mum(std::uint64_t* aaa, std::uint64_t* bbb)
 // read functions. WARNING: we don't care about endianness, so results are different on big endian!
 [[nodiscard]] inline auto r8(const std::uint8_t* ppp) -> std::uint64_t
 {
-    std::uint64_t vvv{};
-    std::memcpy(&vvv, ppp, 8U);
-    return vvv;
+    std::array<std::uint8_t, 8> bytes{};
+    std::copy_n(ppp, 8, bytes.begin());
+    return std::bit_cast<std::uint64_t>(bytes);
 }
 
 [[nodiscard]] inline auto r4(const std::uint8_t* ppp) -> std::uint64_t
 {
-    std::uint32_t vvv{};
-    std::memcpy(&vvv, ppp, 4);
-    return vvv;
+    std::array<std::uint8_t, 4> bytes{};
+    std::copy_n(ppp, 4, bytes.begin());
+    return static_cast<std::uint64_t>(std::bit_cast<std::uint32_t>(bytes));
 }
 
 // reads 1, 2, or 3 bytes

--- a/test/fixed_red_black_tree_view_test.cpp
+++ b/test/fixed_red_black_tree_view_test.cpp
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstddef>
@@ -193,7 +194,7 @@ TEST(FixedRedBlackTreeView, SizeCalculation)
 
     // Test set whose memory has been zero'ed out.
     std::byte buf[sizeof(FixedSetType)];
-    std::memset(buf, 0, sizeof(FixedSetType));
+    std::ranges::fill(buf, std::byte{0});
     auto view4 = FixedRedBlackTreeRawView(
         buf,
         sizeof(FixedSetType::value_type),

--- a/test/string_literal_test.cpp
+++ b/test/string_literal_test.cpp
@@ -2,8 +2,8 @@
 
 #include <gtest/gtest.h>
 
-#include <cstring>
 #include <string>
+#include <string_view>
 #include <type_traits>
 
 namespace fixed_containers
@@ -17,11 +17,11 @@ TEST(StringLiteral, Compare)
 {
     static constexpr const char* POINTER = "blah";
     static_assert(8 == sizeof(POINTER));  // NOLINT(bugprone-sizeof-expression)
-    ASSERT_EQ(4, std::strlen(POINTER));   // not-constexpr
+    static_assert(4 == std::string_view{POINTER}.size());
 
     static constexpr const char ARRAY[5] = "blah";
     static_assert(5 == sizeof(ARRAY));
-    ASSERT_EQ(4, std::strlen(ARRAY));  // not-constexpr
+    static_assert(4 == std::string_view{ARRAY}.size());
 
     static constexpr StringLiteral STRING_LITERAL = "blah";
     static_assert(4 == STRING_LITERAL.size());


### PR DESCRIPTION
By replacing unsafe functions with safe alternatives and 1 suppression