### PR TITLE
docs: fix bzlmod module name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,9 +361,9 @@ target_link_libraries(<your_binary> fixed_containers::fixed_containers)
 ### bazel
 If you are managing dependencies with the newer bzlmod system, use the following in your `MODULE.bazel` file:
 ```
-bazel_dep(name = "fixed_containers")
+bazel_dep(name = "fixed-containers", repo_name = "fixed_containers")
 archive_override(
-    module_name = "fixed_containers",
+    module_name = "fixed-containers",
     strip_prefix = "fixed-containers-<commit>",
     urls = ["https://github.com/teslamotors/fixed-containers/archive/<commit>.tar.gz"],
 )


### PR DESCRIPTION
The `MODULE.bazel` in this repo declares the module as `fixed-containers` (hyphen), but the README bzlmod snippet used `fixed_containers` (underscore) for both `bazel_dep` and `archive_override`.

In Bazel bzlmod, the name passed to `bazel_dep` must exactly match the `name` in the dependency's `module()` call. Using the wrong name causes bazel to fail resolving the module. This was reported in #190.

The fix uses `fixed-containers` in both `bazel_dep` and `archive_override`, and adds `repo_name = "fixed_containers"` to `bazel_dep` so downstream BUILD files can continue referencing targets with the `@fixed_containers//` prefix unchanged.

Testing: verified by reading `MODULE.bazel` (name = "fixed-containers") and cross-checking Bazel bzlmod documentation, which states that the `name` argument to `bazel_dep` must match the module name in the dependency's own `MODULE.bazel`.

Fixes #190