### PR TITLE
Fix FixedString::substr to accept pos == size()

### DIFF
--- a/include/fixed_containers/fixed_string.hpp
+++ b/include/fixed_containers/fixed_string.hpp
@@ -631,7 +631,7 @@ public:
         const std_transition::source_location& loc =
             std_transition::source_location::current()) const
     {
-        if (preconditions::test(pos < length()))
+        if (preconditions::test(pos <= length()))
         {
             Checking::out_of_range(pos, length(), loc);
         }

--- a/test/fixed_string_test.cpp
+++ b/test/fixed_string_test.cpp
@@ -2017,6 +2017,11 @@ TEST(FixedString, Substring)
     static_assert(VAL1.substr(1, 2) == "12");
     static_assert(VAL1.substr(2, 2) == "23");
 
+    // substr(pos) is valid for pos == size() and yields an empty string, matching
+    // std::string/std::string_view. Only pos > size() is out of range.
+    static_assert(VAL1.substr(VAL1.length()).empty());
+    static_assert(VAL1.substr(4, 2).empty());
+
     EXPECT_DEATH((void)VAL1.substr(5, 1), "");
 }
 


### PR DESCRIPTION
`std::string::substr` and `std::string_view::substr` only throw when `pos > size()`; `substr(size())` is well-defined and returns an empty string.

`FixedString::substr` guards with `pos < length()`, so `substr(length())` trips the `out_of_range` check (an `abort()` under the default `SequenceContainerAbortChecking`) instead of returning an empty view:

```cpp
if (preconditions::test(pos < length()))  // fires when pos >= length()
{
    Checking::out_of_range(pos, length(), loc);
}
```

`preconditions::test` returns true when its argument is false, so this rejects `pos == length()`, which the standard accepts.

Repro:
```cpp
FixedString<7> fs{"0123"};        // length() == 4
fs.substr(4);                      // aborts; std::string("0123").substr(4) == ""
```

The sibling `erase(index, count)` added recently in the same header already uses the correct `index <= length()` bound for the same kind of position precondition, so this is just lining `substr` up with it and with the standard.

Fix is one character (`<` to `<=`). Added boundary assertions to `TEST(FixedString, Substring)` covering `substr(length())` and `substr(4, 2)`; the existing `substr(5, 1)` death test (strictly past the end) still holds. The new `static_assert`s fail to compile before the fix because the out-of-range branch is not usable in a constant expression. Full FixedString suite passes.