### PR TITLE
Guard 64-bit iterator size static_asserts for non 64-bit targets

### DIFF
--- a/test/circular_integer_range_iterator_test.cpp
+++ b/test/circular_integer_range_iterator_test.cpp
@@ -15,9 +15,14 @@ static_assert(TriviallyCopyable<CircularIntegerRangeIterator<>>);
 
 static_assert(RandomAccessEntryProvider<CircularIntegerRangeEntryProvider<>>);
 
+// These exact byte sizes assume a 64-bit data model. On platforms with narrower pointers
+// and std::size_t, such as wasm32, the iterators are smaller, so guard the checks to
+// 64-bit targets to avoid false failures.
+#if defined(__SIZEOF_POINTER__) && __SIZEOF_POINTER__ == 8
 static_assert(sizeof(CircularIntegerRangeIterator<IteratorDirection::FORWARD, IntegerRange>) == 32);
 static_assert(sizeof(CircularIntegerRangeIterator<IteratorDirection::FORWARD,
                                                   CompileTimeIntegerRange<0, 3>>) == 24);
+#endif
 TEST(CircularIntegerRangeIterator, DefaultConstructor)
 {
     using ItType = CircularIntegerRangeIterator<IteratorDirection::FORWARD>;

--- a/test/filtered_integer_range_iterator_test.cpp
+++ b/test/filtered_integer_range_iterator_test.cpp
@@ -64,6 +64,10 @@ static_assert(BidirectionalEntryProvider<FilteredIntegerRangeEntryProvider<Alway
 static_assert(FilteredIntegerRangeEntryProvider<AlwaysTruePredicate>{} ==
               FilteredIntegerRangeEntryProvider<AlwaysTruePredicate>{});
 
+// These exact byte sizes assume a 64-bit data model. On platforms with narrower pointers
+// and std::size_t, such as wasm32, the iterators are smaller, so guard the checks to
+// 64-bit targets to avoid false failures.
+#if defined(__SIZEOF_POINTER__) && __SIZEOF_POINTER__ == 8
 static_assert(sizeof(FilteredIntegerRangeIterator<AlwaysTruePredicate,
                                                   IteratorDirection::FORWARD,
                                                   IntegerRange>) == 32);
@@ -73,6 +77,7 @@ static_assert(sizeof(FilteredIntegerRangeIterator<AlwaysTruePredicate,
 static_assert(sizeof(FilteredIntegerRangeIterator<SpecificValuePredicate,
                                                   IteratorDirection::FORWARD,
                                                   CompileTimeIntegerRange<0, 3>>) == 24);
+#endif
 
 }  // namespace
 

--- a/test/integer_range_iterator_test.cpp
+++ b/test/integer_range_iterator_test.cpp
@@ -22,10 +22,15 @@ static_assert(TriviallyCopyable<IotaView1>);
 static_assert(TriviallyCopyable<decltype(IotaView1{}.begin())>);
 // Some implementations of iota_view's iterator can allow it to go out of range
 // static_assert(*std::next(IotaView1{0, 3}.begin(), 15) == 15);
+// These exact byte sizes assume a 64-bit data model. On platforms with narrower
+// pointers and std::size_t, such as wasm32, the sizes are smaller, so guard the
+// checks to 64-bit targets to avoid false failures.
+#if defined(__SIZEOF_POINTER__) && __SIZEOF_POINTER__ == 8
 static_assert(sizeof(IotaView1) == 16ULL);
 static_assert(sizeof(IotaView1{}.begin()) == 8ULL);
 // Need both range and the iterator to make a range-enforcing iterator
 static_assert(sizeof(IotaView1) + sizeof(IotaView1{}.begin()) == 24ULL);
+#endif
 #endif
 }  // namespace
 
@@ -33,9 +38,14 @@ static_assert(TriviallyCopyable<IntegerRangeIterator<>>);
 
 static_assert(RandomAccessEntryProvider<IntegerRangeEntryProvider<>>);
 
+// These exact byte sizes assume a 64-bit data model. On platforms with narrower pointers
+// and std::size_t, such as wasm32, the iterators are smaller, so guard the checks to
+// 64-bit targets to avoid false failures.
+#if defined(__SIZEOF_POINTER__) && __SIZEOF_POINTER__ == 8
 static_assert(sizeof(IntegerRangeIterator<IteratorDirection::FORWARD, IntegerRange>) == 24);
 static_assert(
     sizeof(IntegerRangeIterator<IteratorDirection::FORWARD, CompileTimeIntegerRange<0, 3>>) == 16);
+#endif
 
 TEST(IntegerRangeIterator, DefaultConstructor)
 {


### PR DESCRIPTION
## Problem

The integer range iterator tests assert the exact byte size of several iterator types with hardcoded values that assume a 64-bit data model, for example:

```cpp
static_assert(sizeof(IntegerRangeIterator<IteratorDirection::FORWARD, IntegerRange>) == 24);
static_assert(sizeof(CircularIntegerRangeIterator<IteratorDirection::FORWARD, IntegerRange>) == 32);
```

These iterators are composed of std::size_t-width members. On platforms with narrower pointers and std::size_t, such as wasm32, the iterators are smaller, so these static_asserts fail to compile. This is one of the remaining failures from issue #128 when compiling the project with emscripten, after the unrelated `iterator_` two phase lookup fix in #129. The reporter confirmed these size and death test asserts were the only remaining errors.

## Root cause

The asserted byte counts are valid only under a 64-bit data model. They are layout sanity checks, not portability requirements, but they were written unconditionally, so any target where `sizeof(std::size_t)` is not 8 breaks the build. I also verified that the sizes are not a clean multiple of `sizeof(std::size_t)` on 32-bit targets because of alignment of the iterator wrappers, so a per-platform recomputation would be fragile.

## Fix

Wrap the size static_asserts in a `defined(__SIZEOF_POINTER__) && __SIZEOF_POINTER__ == 8` guard in the three affected test files:

- `test/integer_range_iterator_test.cpp`
- `test/circular_integer_range_iterator_test.cpp`
- `test/filtered_integer_range_iterator_test.cpp`

This mirrors the existing platform gating already used in these files, keeps the layout checks fully enforced on the primary 64-bit configurations, and skips them where the exact byte count is not meaningful. No library or runtime behavior changes, this only affects compile-time layout assertions in tests.

## Verification

- 64-bit native, where `__SIZEOF_POINTER__ == 8`: all three test translation units compile with `-std=c++20`, the guarded asserts stay active and pass.
- 32-bit simulation with `-m32`, where `__SIZEOF_POINTER__ == 4`, reproducing the narrower wasm32 width: an isolated probe of the same asserts failed before this change with the exact errors reported in the issue, and compiles clean after, since the guard now skips them.
- clang-format applied to all three files, the diff is format stable.

Out of scope: the `EXPECT_DEATH` errors under emscripten come from gtest death tests not being available on that platform, which is a gtest and toolchain limitation rather than a fixed-containers issue, so they are left untouched.

Fixes #128