### PR TITLE
Add and_then, transform, and or_else to OptionalReference

### DIFF
--- a/include/fixed_containers/optional_reference.hpp
+++ b/include/fixed_containers/optional_reference.hpp
@@ -5,9 +5,11 @@
 #include "fixed_containers/source_location.hpp"
 
 #include <compare>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <type_traits>
+#include <utility>
 
 namespace fixed_containers
 {
@@ -134,6 +136,50 @@ public:
     {
         check_bad_optional_access(std_transition::source_location::current());
         return *val();
+    }
+
+    // Monadic operations, mirroring the C++23 additions to std::optional. There is only one
+    // overload of each because `reference` and `const_reference` are both `T&`: constness of
+    // an OptionalReference applies to the reference, not to the referent.
+    template <class F>
+    [[nodiscard]] constexpr std::remove_cvref_t<std::invoke_result_t<F, const_reference>> and_then(
+        F&& func) const
+    {
+        using Result = std::remove_cvref_t<std::invoke_result_t<F, const_reference>>;
+        if (!has_value())
+        {
+            return Result{};
+        }
+
+        return std::invoke(std::forward<F>(func), *val());
+    }
+
+    // Unlike `and_then()`, this returns a std::optional: the callable produces a value, so there
+    // would be nothing left for an OptionalReference to refer to.
+    template <class F>
+    [[nodiscard]] constexpr std::optional<
+        std::remove_cv_t<std::invoke_result_t<F, const_reference>>>
+    transform(F&& func) const
+    {
+        using Result = std::optional<std::remove_cv_t<std::invoke_result_t<F, const_reference>>>;
+        if (!has_value())
+        {
+            return Result{};
+        }
+
+        return Result{std::invoke(std::forward<F>(func), *val())};
+    }
+
+    template <class F>
+    [[nodiscard]] constexpr Self or_else(F&& func) const
+        requires(std::is_same_v<std::remove_cvref_t<std::invoke_result_t<F>>, Self>)
+    {
+        if (!has_value())
+        {
+            return std::forward<F>(func)();
+        }
+
+        return *this;
     }
 
     constexpr void reset() noexcept { val() = nullptr; }

--- a/test/optional_reference_test.cpp
+++ b/test/optional_reference_test.cpp
@@ -488,7 +488,14 @@ TEST(OptionalReference, Transform)
 TEST(OptionalReference, OrElse)
 {
     static constexpr int FALLBACK = 7;
-    static constexpr auto TO_FALLBACK = []() { return OptionalReference<const int>{FALLBACK}; };
+    // Bind a named lvalue reference before constructing. Naming `FALLBACK` directly here lets MSVC
+    // apply the lvalue-to-rvalue conversion, which selects the deleted `OptionalReference(T&&)`
+    // overload that exists to stop the reference binding to a temporary.
+    static constexpr auto TO_FALLBACK = []()
+    {
+        const int& fallback = FALLBACK;
+        return OptionalReference<const int>{fallback};
+    };
 
     {
         static constexpr int VAL1 = 42;

--- a/test/optional_reference_test.cpp
+++ b/test/optional_reference_test.cpp
@@ -415,4 +415,103 @@ TEST(OptionalReference, ConstHandling)
     }
 }
 
+TEST(OptionalReference, AndThen)
+{
+    static constexpr auto TO_DOUBLED = [](const int& val)
+    { return val % 2 == 0 ? std::optional<int>{val * 2} : std::optional<int>{}; };
+
+    {
+        static constexpr int VAL1 = 21;
+        constexpr OptionalReference<const int> OPT_REF{VAL1};
+        static_assert(!OPT_REF.and_then(TO_DOUBLED).has_value());
+    }
+    {
+        static constexpr int VAL1 = 42;
+        constexpr OptionalReference<const int> OPT_REF{VAL1};
+        static_assert(OPT_REF.and_then(TO_DOUBLED) == std::optional<int>{84});
+    }
+    {
+        constexpr OptionalReference<const int> OPT_REF{};
+        static_assert(!OPT_REF.and_then(TO_DOUBLED).has_value());
+    }
+    {
+        // The callable is free to return an OptionalReference too.
+        static constexpr int VAL1 = 42;
+        constexpr OptionalReference<const int> OPT_REF{VAL1};
+        constexpr auto IDENTITY = [](const int& val) { return OptionalReference<const int>{val}; };
+        static_assert(&OPT_REF.and_then(IDENTITY).value() == &VAL1);
+    }
+    {
+        // Not invoked when empty.
+        int call_count = 0;
+        const OptionalReference<const int> opt_ref{};
+        const auto counting = [&call_count](const int& val)
+        {
+            call_count++;
+            return std::optional<int>{val};
+        };
+        EXPECT_FALSE(opt_ref.and_then(counting).has_value());
+        EXPECT_EQ(0, call_count);
+    }
+}
+
+TEST(OptionalReference, Transform)
+{
+    static constexpr auto TO_HALVED = [](const int& val) { return val / 2; };
+
+    {
+        static constexpr int VAL1 = 42;
+        constexpr OptionalReference<const int> OPT_REF{VAL1};
+        static_assert(OPT_REF.transform(TO_HALVED) == std::optional<int>{21});
+    }
+    {
+        constexpr OptionalReference<const int> OPT_REF{};
+        static_assert(!OPT_REF.transform(TO_HALVED).has_value());
+    }
+    {
+        // The value is copied out, so mutating the referent afterwards does not change it.
+        int val1 = 42;
+        const OptionalReference<int> opt_ref{val1};
+        const std::optional<int> transformed = opt_ref.transform(TO_HALVED);
+        val1 = 0;
+        EXPECT_EQ(std::optional<int>{21}, transformed);
+    }
+    {
+        // Chains after an and_then() that keeps returning an OptionalReference.
+        static constexpr int VAL1 = 42;
+        constexpr OptionalReference<const int> OPT_REF{VAL1};
+        constexpr auto IDENTITY = [](const int& val) { return OptionalReference<const int>{val}; };
+        static_assert(OPT_REF.and_then(IDENTITY).transform(TO_HALVED) == std::optional<int>{21});
+    }
+}
+
+TEST(OptionalReference, OrElse)
+{
+    static constexpr int FALLBACK = 7;
+    static constexpr auto TO_FALLBACK = []() { return OptionalReference<const int>{FALLBACK}; };
+
+    {
+        static constexpr int VAL1 = 42;
+        constexpr OptionalReference<const int> OPT_REF{VAL1};
+        static_assert(&OPT_REF.or_else(TO_FALLBACK).value() == &VAL1);
+    }
+    {
+        constexpr OptionalReference<const int> OPT_REF{};
+        static_assert(&OPT_REF.or_else(TO_FALLBACK).value() == &FALLBACK);
+    }
+    {
+        // Not invoked when a value is present.
+        int call_count = 0;
+        int val1 = 42;
+        const OptionalReference<int> opt_ref{val1};
+        const auto counting = [&call_count]()
+        {
+            call_count++;
+            return OptionalReference<int>{};
+        };
+        EXPECT_TRUE(opt_ref.or_else(counting).has_value());
+        EXPECT_EQ(0, call_count);
+    }
+}
+
 }  // namespace fixed_containers


### PR DESCRIPTION
Closes #197.

Adds `and_then()`, `transform()`, and `or_else()` to `OptionalReference`, following the C++23 `std::optional` monadic operations so code still on C++20 can use the same style.

`transform()` returns a `std::optional` rather than an `OptionalReference` because the callable produces a value and there would be nothing left for a reference to point at. `and_then()` returns whatever the callable returns, so it works with both `std::optional` and another `OptionalReference`. `or_else()` returns the same `OptionalReference` type and is constrained to callables that return it. Each operation has a single overload since `reference` and `const_reference` are both `T&` here, matching the existing decision that constness applies to the reference and not to the referent.

The new tests in `optional_reference_test.cpp` cover the empty and engaged paths at compile time via `static_assert`, check that the callable is not invoked on the short circuit path, and confirm `or_else()` preserves the referent's address. I compiled `test/optional_reference_test.cpp` with `clang++ -std=c++20` against gtest and ran the `OptionalReference.*` suite, 31 tests passing. The same file fails to compile against `main`, which is what the new tests are asserting.
