### PR TITLE
Use decltype(auto) for the return type of to_parameter_pack

### DIFF
--- a/include/fixed_containers/struct_decomposition.hpp
+++ b/include/fixed_containers/struct_decomposition.hpp
@@ -26,7 +26,7 @@ template <std::size_t C /*FIELD_COUNT*/, typename T, typename Func>
 // ifdef-ed to get the nice error message from the static_assert()
     requires(C <= 128)
 #endif
-constexpr auto to_parameter_pack(T& t, Func&& f)
+constexpr decltype(auto) to_parameter_pack(T& t, Func&& f)
 {
     if constexpr (C == 0)
     {

--- a/include/fixed_containers/struct_decomposition_129_to_512.hpp
+++ b/include/fixed_containers/struct_decomposition_129_to_512.hpp
@@ -11,7 +11,7 @@ namespace fixed_containers::struct_decomposition
 // clang-format on
 template <std::size_t C /*FIELD_COUNT*/, typename T, typename Func>
     requires(129 <= C && C <= 512)
-constexpr auto to_parameter_pack(T& t, Func&& f)
+constexpr decltype(auto) to_parameter_pack(T& t, Func&& f)
 {
     // codegen-start
     // clang-format off

--- a/include/fixed_containers/struct_decomposition_513_to_768.hpp
+++ b/include/fixed_containers/struct_decomposition_513_to_768.hpp
@@ -11,7 +11,7 @@ namespace fixed_containers::struct_decomposition
 // clang-format on
 template <std::size_t C /*FIELD_COUNT*/, typename T, typename Func>
     requires(513 <= C && C <= 768)
-constexpr auto to_parameter_pack(T& t, Func&& f)
+constexpr decltype(auto) to_parameter_pack(T& t, Func&& f)
 {
     // codegen-start
     // clang-format off

--- a/include/fixed_containers/struct_decomposition_769_to_1024.hpp
+++ b/include/fixed_containers/struct_decomposition_769_to_1024.hpp
@@ -11,7 +11,7 @@ namespace fixed_containers::struct_decomposition
 // clang-format on
 template <std::size_t C /*FIELD_COUNT*/, typename T, typename Func>
     requires(C >= 769)
-constexpr auto to_parameter_pack(T& t, Func&& f)
+constexpr decltype(auto) to_parameter_pack(T& t, Func&& f)
 {
     // codegen-start
     // clang-format off


### PR DESCRIPTION
This allows the user-specified function passed into to_parameter_pack return anything, including `const` variables and references. For reasons best left unknown, raw `auto` strips references and constness, forcing the fucntion to return-by-value (currently, users work around this by returning pointers).