### PR TITLE
Reduce instruction count on hot container paths

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1731,6 +1731,18 @@ cc_test(
 )
 
 cc_test(
+    name = "algorithm_test",
+    srcs = ["test/algorithm_test.cpp"],
+    deps = [
+        ":algorithm",
+        ":fixed_vector",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+    copts = ["-std=c++20"],
+)
+
+cc_test(
     name = "memory_test",
     srcs = ["test/memory_test.cpp"],
     deps = [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,8 @@ if(BUILD_TESTS)
         add_test(NAME ${TEST_TARGET} COMMAND ${TEST_TARGET})
     endmacro()
 
+    add_executable(algorithm_test test/algorithm_test.cpp)
+    add_test_dependencies(algorithm_test)
     add_executable(circular_indexing_test test/circular_indexing_test.cpp)
     add_test_dependencies(circular_indexing_test)
     add_executable(circular_integer_range_iterator_test test/circular_integer_range_iterator_test.cpp)

--- a/include/fixed_containers/algorithm.hpp
+++ b/include/fixed_containers/algorithm.hpp
@@ -2,7 +2,12 @@
 
 #include "fixed_containers/memory.hpp"
 
+#include <compare>
+#include <cstddef>
+#include <cstring>
 #include <iterator>
+#include <memory>
+#include <type_traits>
 #include <utility>
 
 namespace fixed_containers::algorithm
@@ -12,6 +17,24 @@ namespace fixed_containers::algorithm
 template <class FwdIt1, class FwdIt2>
 constexpr FwdIt2 uninitialized_relocate(FwdIt1 first, FwdIt1 last, FwdIt2 d_first)
 {
+    using ValueType = std::remove_cvref_t<decltype(*first)>;
+    if constexpr (std::contiguous_iterator<FwdIt1> && std::contiguous_iterator<FwdIt2> &&
+                  std::is_trivially_copyable_v<ValueType> &&
+                  std::is_trivially_destructible_v<ValueType>)
+    {
+        if (!std::is_constant_evaluated())
+        {
+            const auto count = std::distance(first, last);
+            if (count > 0)
+            {
+                std::memmove(static_cast<void*>(std::to_address(d_first)),
+                             static_cast<const void*>(std::to_address(first)),
+                             static_cast<std::size_t>(count) * sizeof(ValueType));
+            }
+            return std::next(d_first, count);
+        }
+    }
+
     while (first != last)
     {
         memory::construct_at_address_of(*d_first, std::move(*first));
@@ -27,6 +50,26 @@ constexpr FwdIt2 uninitialized_relocate(FwdIt1 first, FwdIt1 last, FwdIt2 d_firs
 template <class BidirIt1, class BidirIt2>
 constexpr BidirIt2 uninitialized_relocate_backward(BidirIt1 first, BidirIt1 last, BidirIt2 d_last)
 {
+    using ValueType = std::remove_cvref_t<decltype(*first)>;
+    if constexpr (std::contiguous_iterator<BidirIt1> && std::contiguous_iterator<BidirIt2> &&
+                  std::is_trivially_copyable_v<ValueType> &&
+                  std::is_trivially_destructible_v<ValueType>)
+    {
+        if (!std::is_constant_evaluated())
+        {
+            const auto count = std::distance(first, last);
+            if (count > 0)
+            {
+                auto dest_first = std::prev(d_last, count);
+                std::memmove(static_cast<void*>(std::to_address(dest_first)),
+                             static_cast<const void*>(std::to_address(first)),
+                             static_cast<std::size_t>(count) * sizeof(ValueType));
+                return dest_first;
+            }
+            return d_last;
+        }
+    }
+
     while (first != last)
     {
         --d_last;
@@ -53,25 +96,19 @@ constexpr auto lexicographical_compare_three_way(InputIt1 first1,
                                      std::is_same<ReturnType, std::partial_ordering>>,
                   "The return type must be a comparison category type.");
 
-    bool is_exhausted1 = (first1 == last1);
-    bool is_exhausted_2 = (first2 == last2);
-    for (; !is_exhausted1 && !is_exhausted_2;)
+    for (; first1 != last1 && first2 != last2; ++first1, ++first2)
     {
         if (auto ccc = comp(*first1, *first2); ccc != ReturnType::equal)
         {
             return ccc;
         }
-        std::advance(first1, 1);
-        std::advance(first2, 1);
-        is_exhausted1 = (first1 == last1);
-        is_exhausted_2 = (first2 == last2);
     }
 
-    if (!is_exhausted1)
+    if (first1 != last1)
     {
         return std::strong_ordering::greater;
     }
-    if (!is_exhausted_2)
+    if (first2 != last2)
     {
         return std::strong_ordering::less;
     }

--- a/include/fixed_containers/circular_indexing.hpp
+++ b/include/fixed_containers/circular_indexing.hpp
@@ -4,6 +4,7 @@
 #include "fixed_containers/int_math.hpp"
 #include "fixed_containers/integer_range.hpp"
 
+#include <bit>
 #include <compare>
 #include <cstdint>
 #include <tuple>
@@ -27,22 +28,34 @@ constexpr CyclesAndInteger increment_index_with_wraparound(const IntegerRangeTyp
                                                            std::size_t index,
                                                            std::size_t n)
 {
-    if (range.distance() == 0)
+    const std::size_t range_size = range.distance();
+    if (range_size == 0)
     {
         // Default constructed
         assert_or_abort(index == 0);
         return {};
     }
 
-    const std::size_t range_size = range.distance();
+    const std::size_t start = range.start_inclusive();
+    // Fast path for the common [0, N) range used by FixedDeque: a single add + remainder.
+    // When N is a power of two the compiler turns `%`/`/` into AND/SHIFT.
+    if (start == 0)
+    {
+        if (std::has_single_bit(range_size))
+        {
+            return {.cycles = static_cast<std::int64_t>((index + n) >> std::countr_zero(range_size)),
+                    .integer = (index + n) & (range_size - 1)};
+        }
+        return {.cycles = static_cast<std::int64_t>((index + n) / range_size),
+                .integer = (index + n) % range_size};
+    }
+
     const std::size_t new_index_unwrapped = index + n;
     const auto adjust_to_zero =
-        int_math::safe_subtract(new_index_unwrapped, range.start_inclusive())
-            .template cast<std::size_t>();
+        int_math::safe_subtract(new_index_unwrapped, start).template cast<std::size_t>();
     const std::size_t quotient = adjust_to_zero / range_size;
     const std::size_t remainder = adjust_to_zero - (quotient * range_size);
-    return {.cycles = static_cast<int64_t>(quotient),
-            .integer = remainder + range.start_inclusive()};
+    return {.cycles = static_cast<int64_t>(quotient), .integer = remainder + start};
 }
 
 template <IsIntegerRange IntegerRangeType>
@@ -50,14 +63,33 @@ constexpr CyclesAndInteger decrement_index_with_wraparound(const IntegerRangeTyp
                                                            std::size_t index,
                                                            std::size_t n)
 {
-    if (range.distance() == 0)
+    const std::size_t range_size = range.distance();
+    if (range_size == 0)
     {
         // Default constructed
         assert_or_abort(index == 0);
         return {};
     }
 
-    const std::size_t range_size = range.distance();
+    const std::size_t start = range.start_inclusive();
+    if (start == 0)
+    {
+        // Keep `integer` in [0, range_size). `index` can be far outside that interval
+        // (FixedDeque uses a virtual origin near SIZE_MAX/2).
+        const std::size_t index_mod = index % range_size;
+        const std::size_t n_mod = n % range_size;
+        const std::size_t n_cycles = n / range_size;
+        if (n_mod <= index_mod)
+        {
+            return {.cycles = static_cast<std::int64_t>(index / range_size) -
+                              static_cast<std::int64_t>(n_cycles),
+                    .integer = index_mod - n_mod};
+        }
+        return {.cycles = static_cast<std::int64_t>(index / range_size) -
+                          static_cast<std::int64_t>(n_cycles + 1),
+                .integer = index_mod + range_size - n_mod};
+    }
+
     const std::size_t negative_cycles = (n / range_size) + 1;
     const auto positive_modulo =
         int_math::safe_subtract(negative_cycles * range_size, n).template cast<std::size_t>();

--- a/include/fixed_containers/enum_array.hpp
+++ b/include/fixed_containers/enum_array.hpp
@@ -85,7 +85,7 @@ public:
         for (const auto& [label, value] : range)
         {
             const std::size_t ordinal = EnumAdapterType::ordinal(label);
-            values().at(ordinal) = value;
+            values()[ordinal] = value;
         }
     }
 
@@ -108,22 +108,22 @@ public:
     constexpr reference at(const L& label)
     {
         const std::size_t ordinal = EnumAdapterType::ordinal(label);
-        return values().at(ordinal);
+        return values()[ordinal];
     }
     [[nodiscard]] constexpr const_reference at(const L& label) const
     {
         const std::size_t ordinal = EnumAdapterType::ordinal(label);
-        return values().at(ordinal);
+        return values()[ordinal];
     }
     constexpr reference operator[](const L& label)
     {
         const std::size_t ordinal = EnumAdapterType::ordinal(label);
-        return values().at(ordinal);
+        return values()[ordinal];
     }
     constexpr const_reference operator[](const L& label) const
     {
         const std::size_t ordinal = EnumAdapterType::ordinal(label);
-        return values().at(ordinal);
+        return values()[ordinal];
     }
     constexpr reference front() { return values().front(); }
     [[nodiscard]] constexpr const_reference front() const { return values().front(); }

--- a/include/fixed_containers/fixed_deque.hpp
+++ b/include/fixed_containers/fixed_deque.hpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cstddef>
 #include <initializer_list>
 #include <iterator>
@@ -52,12 +53,26 @@ class FixedDequeBase
     static constexpr std::size_t increment_index_with_wraparound(std::size_t index,
                                                                  std::size_t n = 1)
     {
-        return circular_indexing::increment_index_with_wraparound(FULL_RANGE, index, n).integer;
+        if constexpr (MAXIMUM_SIZE > 0 && std::has_single_bit(MAXIMUM_SIZE))
+        {
+            return (index + n) & (MAXIMUM_SIZE - 1);
+        }
+        else
+        {
+            return circular_indexing::increment_index_with_wraparound(FULL_RANGE, index, n).integer;
+        }
     }
     static constexpr std::size_t decrement_index_with_wraparound(std::size_t index,
                                                                  std::size_t n = 1)
     {
-        return circular_indexing::decrement_index_with_wraparound(FULL_RANGE, index, n).integer;
+        if constexpr (MAXIMUM_SIZE > 0 && std::has_single_bit(MAXIMUM_SIZE))
+        {
+            return (index - n) & (MAXIMUM_SIZE - 1);
+        }
+        else
+        {
+            return circular_indexing::decrement_index_with_wraparound(FULL_RANGE, index, n).integer;
+        }
     }
 
 public:
@@ -116,7 +131,7 @@ private:
             assert_or_abort(starting_index_and_distance_->to_range().contains(current_index_));
             const std::size_t index =
                 decrement_index_with_wraparound(current_index_, FIXED_DEQUE_STARTING_OFFSET);
-            return optional_storage_detail::get(array_->at(index));
+            return optional_storage_detail::get((*array_)[index]);
         }
 
         template <bool IS_CONST2>

--- a/include/fixed_containers/fixed_doubly_linked_list.hpp
+++ b/include/fixed_containers/fixed_doubly_linked_list.hpp
@@ -116,15 +116,15 @@ public:
 public:
     [[nodiscard]] constexpr const IndexType& next_of(IndexType index) const
     {
-        return chain().at(index).next;
+        return chain()[index].next;
     }
-    [[nodiscard]] constexpr IndexType& next_of(IndexType index) { return chain().at(index).next; }
+    [[nodiscard]] constexpr IndexType& next_of(IndexType index) { return chain()[index].next; }
 
     [[nodiscard]] constexpr const IndexType& prev_of(IndexType index) const
     {
-        return chain().at(index).prev;
+        return chain()[index].prev;
     }
-    [[nodiscard]] constexpr IndexType& prev_of(IndexType index) { return chain().at(index).prev; }
+    [[nodiscard]] constexpr IndexType& prev_of(IndexType index) { return chain()[index].prev; }
 
 private:
     [[nodiscard]] constexpr const StorageType& storage() const

--- a/include/fixed_containers/fixed_index_based_storage.hpp
+++ b/include/fixed_containers/fixed_index_based_storage.hpp
@@ -171,10 +171,10 @@ public:
 
     [[nodiscard]] constexpr bool full() const noexcept { return nodes().full(); }
 
-    constexpr T& at(const std::size_t index) noexcept { return nodes().at(index); }
+    constexpr T& at(const std::size_t index) noexcept { return nodes().data()[index]; }
     [[nodiscard]] constexpr const T& at(const std::size_t index) const noexcept
     {
-        return nodes().at(index);
+        return nodes().data()[index];
     }
 
     template <class... Args>
@@ -186,8 +186,8 @@ public:
 
     constexpr std::size_t delete_at_and_return_repositioned_index(const std::size_t index) noexcept
     {
-        memory::destroy_at_address_of(nodes().at(index));
-        memory::construct_at_address_of(nodes().at(index), std::move(nodes().back()));
+        memory::destroy_at_address_of(nodes().data()[index]);
+        memory::construct_at_address_of(nodes().data()[index], std::move(nodes().back()));
         nodes().pop_back();
         return nodes().size();
     }

--- a/include/fixed_containers/fixed_robinhood_hashtable.hpp
+++ b/include/fixed_containers/fixed_robinhood_hashtable.hpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cstdint>
 #include <utility>
 
@@ -172,16 +173,27 @@ public:
         // bucket also encodes. This does not restrict the size of the table because we store the
         // value_index in 32 bits, so the 56 left in this hash are plenty for our needs.
         const std::uint64_t shifted_hash = hash >> Bucket::FINGERPRINT_BITS;
-        return static_cast<SizeType>(shifted_hash % INTERNAL_TABLE_SIZE);
+        if constexpr (std::has_single_bit(INTERNAL_TABLE_SIZE))
+        {
+            return static_cast<SizeType>(shifted_hash & (INTERNAL_TABLE_SIZE - 1));
+        }
+        else
+        {
+            return static_cast<SizeType>(shifted_hash % INTERNAL_TABLE_SIZE);
+        }
     }
 
     [[nodiscard]] static constexpr SizeType next_bucket_index(SizeType bucket_index)
     {
-        if (bucket_index + 1 < INTERNAL_TABLE_SIZE)
+        if constexpr (std::has_single_bit(INTERNAL_TABLE_SIZE))
         {
-            return bucket_index + 1;
+            return (bucket_index + 1U) & static_cast<SizeType>(INTERNAL_TABLE_SIZE - 1U);
         }
-        return 0;
+        else
+        {
+            const SizeType next = bucket_index + 1U;
+            return next == static_cast<SizeType>(INTERNAL_TABLE_SIZE) ? 0 : next;
+        }
     }
 
     constexpr void place_and_shift_up(Bucket bucket, SizeType table_loc)
@@ -393,10 +405,20 @@ public:
 
 constexpr std::size_t default_bucket_count(std::size_t value_count)
 {
-    // oversize the bucket array by 30%
-    // TODO: think about the oversize percentage
-    // TODO: round to a nearby power of 2 to improve modulus performance
-    return (value_count * 130) / 100;
+    // Oversize the bucket array by ~30%, then round up to a power of two so
+    // `hash % table_size` and wraparound become a single AND instead of a divide.
+    if (value_count <= 1)
+    {
+        return value_count;
+    }
+
+    const std::size_t oversized = (value_count * 130) / 100;
+    const std::size_t rounded = std::bit_ceil(oversized);
+    if (rounded > Bucket::MAX_NUM_BUCKETS)
+    {
+        return std::min(std::max(oversized, value_count), Bucket::MAX_NUM_BUCKETS);
+    }
+    return rounded;
 }
 
 }  // namespace fixed_containers::fixed_robinhood_hashtable_detail

--- a/include/fixed_containers/preconditions.hpp
+++ b/include/fixed_containers/preconditions.hpp
@@ -2,6 +2,11 @@
 
 namespace fixed_containers::preconditions
 {
+// Returns true when `condition` failed (i.e. the error path should run).
+// Marked always_inline so the [[unlikely]] hint is visible at every call site after inlining.
+#if defined(__GNUC__)
+[[gnu::always_inline]]
+#endif
 constexpr bool test(const bool condition)
 {
     if (!condition) [[unlikely]]

--- a/include/fixed_containers/random_access_iterator.hpp
+++ b/include/fixed_containers/random_access_iterator.hpp
@@ -116,7 +116,7 @@ public:
 
     constexpr Self& operator++() noexcept
     {
-        operator+=(1);
+        addition_assignment_op_impl(1);
         return *this;
     }
 
@@ -129,7 +129,7 @@ public:
 
     constexpr Self& operator--() noexcept
     {
-        operator-=(1);
+        subtraction_assignment_op_impl(1);
         return *this;
     }
 

--- a/include/fixed_containers/random_access_iterator_transformer.hpp
+++ b/include/fixed_containers/random_access_iterator_transformer.hpp
@@ -96,60 +96,60 @@ public:
 
     constexpr reference operator[](difference_type off) const
     {
-        return unary_function_(*std::next(iterator_, off));
+        return unary_function_(iterator_[off]);
     }
 
     constexpr Self& operator++() noexcept
     {
-        std::advance(iterator_, 1);
+        ++iterator_;
         return *this;
     }
 
     constexpr Self operator++(int) & noexcept
     {
         Self tmp = *this;
-        std::advance(iterator_, 1);
+        ++iterator_;
         return tmp;
     }
 
     constexpr Self& operator--() noexcept
     {
-        std::advance(iterator_, -1);
+        --iterator_;
         return *this;
     }
 
     constexpr Self operator--(int) & noexcept
     {
         Self tmp = *this;
-        std::advance(iterator_, -1);
+        --iterator_;
         return tmp;
     }
 
     constexpr Self& operator+=(difference_type off)
     {
-        std::advance(iterator_, off);
+        iterator_ += off;
         return *this;
     }
 
     constexpr Self operator+(difference_type off) const
     {
-        return Self(std::next(iterator_, off), unary_function_);
+        return Self(iterator_ + off, unary_function_);
     }
 
     friend constexpr Self operator+(difference_type off, const Self& other)
     {
-        return Self{std::next(other.iterator_, off), other.unary_function_};
+        return Self{other.iterator_ + off, other.unary_function_};
     }
 
     constexpr Self& operator-=(difference_type off)
     {
-        std::advance(iterator_, -off);
+        iterator_ -= off;
         return *this;
     }
 
     constexpr Self operator-(difference_type off) const
     {
-        return Self(std::prev(iterator_, off), unary_function_);
+        return Self(iterator_ - off, unary_function_);
     }
 
     constexpr difference_type operator-(const Self& other) const

--- a/include/fixed_containers/wyhash.hpp
+++ b/include/fixed_containers/wyhash.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <bit>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <iterator>
 #include <memory>
@@ -64,16 +65,16 @@ constexpr void mum(std::uint64_t* aaa, std::uint64_t* bbb)
 // read functions. WARNING: we don't care about endianness, so results are different on big endian!
 [[nodiscard]] inline auto r8(const std::uint8_t* ppp) -> std::uint64_t
 {
-    std::array<std::uint8_t, 8> bytes{};
-    std::copy_n(ppp, 8, bytes.begin());
-    return std::bit_cast<std::uint64_t>(bytes);
+    std::uint64_t value{};
+    std::memcpy(&value, ppp, sizeof(value));
+    return value;
 }
 
 [[nodiscard]] inline auto r4(const std::uint8_t* ppp) -> std::uint64_t
 {
-    std::array<std::uint8_t, 4> bytes{};
-    std::copy_n(ppp, 4, bytes.begin());
-    return static_cast<std::uint64_t>(std::bit_cast<std::uint32_t>(bytes));
+    std::uint32_t value{};
+    std::memcpy(&value, ppp, sizeof(value));
+    return value;
 }
 
 // reads 1, 2, or 3 bytes

--- a/test/algorithm_test.cpp
+++ b/test/algorithm_test.cpp
@@ -1,0 +1,79 @@
+#include "fixed_containers/algorithm.hpp"
+#include "fixed_containers/fixed_vector.hpp"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <iterator>
+
+namespace fixed_containers
+{
+TEST(Algorithm, UninitializedRelocateTrivial)
+{
+    std::array<int, 8> values{0, 1, 2, 3, 4, 5, 6, 7};
+    std::array<int, 8> dest{};
+
+    const auto* const out =
+        algorithm::uninitialized_relocate(values.begin() + 1, values.begin() + 5, dest.begin());
+    EXPECT_EQ(out, dest.begin() + 4);
+    EXPECT_EQ(dest[0], 1);
+    EXPECT_EQ(dest[1], 2);
+    EXPECT_EQ(dest[2], 3);
+    EXPECT_EQ(dest[3], 4);
+}
+
+TEST(Algorithm, UninitializedRelocateOverlapping)
+{
+    std::array<int, 8> values{0, 1, 2, 3, 4, 5, 6, 7};
+    algorithm::uninitialized_relocate_backward(
+        values.begin() + 1, values.begin() + 4, values.begin() + 6);
+    EXPECT_EQ(values[3], 1);
+    EXPECT_EQ(values[4], 2);
+    EXPECT_EQ(values[5], 3);
+}
+
+TEST(Algorithm, UninitializedRelocateEmpty)
+{
+    std::array<int, 2> values{1, 2};
+    auto* const out =
+        algorithm::uninitialized_relocate(values.begin(), values.begin(), values.begin());
+    EXPECT_EQ(out, values.begin());
+}
+
+TEST(Algorithm, LexicographicalCompareThreeWay)
+{
+    static constexpr std::array LHS{1, 2, 3};
+    static constexpr std::array RHS{1, 2, 4};
+    static_assert(algorithm::lexicographical_compare_three_way(
+                      LHS.begin(), LHS.end(), LHS.begin(), LHS.end()) == 0);
+    static_assert(algorithm::lexicographical_compare_three_way(
+                      LHS.begin(), LHS.end(), RHS.begin(), RHS.end()) < 0);
+    static_assert(algorithm::lexicographical_compare_three_way(
+                      RHS.begin(), RHS.end(), LHS.begin(), LHS.end()) > 0);
+}
+
+TEST(Algorithm, FixedVectorInsertEraseUsesRelocate)
+{
+    FixedVector<int, 8> values{1, 2, 4, 5};
+    values.insert(values.begin() + 2, 3);
+    EXPECT_EQ(values.size(), 5);
+    EXPECT_EQ(values[0], 1);
+    EXPECT_EQ(values[1], 2);
+    EXPECT_EQ(values[2], 3);
+    EXPECT_EQ(values[3], 4);
+    EXPECT_EQ(values[4], 5);
+
+    values.erase(values.begin() + 1, values.begin() + 3);
+    EXPECT_EQ(values.size(), 3);
+    EXPECT_EQ(values[0], 1);
+    EXPECT_EQ(values[1], 4);
+    EXPECT_EQ(values[2], 5);
+}
+
+TEST(Algorithm, FixedVectorIteratorIsContiguous)
+{
+    using Iterator = FixedVector<int, 4>::iterator;
+    static_assert(std::contiguous_iterator<Iterator>);
+}
+
+}  // namespace fixed_containers

--- a/test/circular_indexing_test.cpp
+++ b/test/circular_indexing_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <limits>
 
 namespace fixed_containers::circular_indexing
 {
@@ -36,6 +37,18 @@ TEST(CyclesAndInteger, IncrementIndexWithWraparound)
         static_assert(7 == RESULT.cycles);
         static_assert(9 == RESULT.integer);
     }
+    {
+        static constexpr IntegerRange RANGE = IntegerRange::closed_open(0, 16);
+        constexpr CyclesAndInteger RESULT = increment_index_with_wraparound(RANGE, 14, 5);
+        static_assert(1 == RESULT.cycles);
+        static_assert(3 == RESULT.integer);
+    }
+    {
+        static constexpr IntegerRange RANGE = IntegerRange::closed_open(0, 1);
+        constexpr CyclesAndInteger RESULT = increment_index_with_wraparound(RANGE, 0, 7);
+        static_assert(7 == RESULT.cycles);
+        static_assert(0 == RESULT.integer);
+    }
 }
 
 TEST(CyclesAndInteger, DecrementIndexWithWraparound)
@@ -65,6 +78,26 @@ TEST(CyclesAndInteger, DecrementIndexWithWraparound)
         constexpr CyclesAndInteger RESULT = decrement_index_with_wraparound(RANGE, START_INDEX, 62);
         static_assert(-5 == RESULT.cycles);
         static_assert(5 == RESULT.integer);
+    }
+    {
+        static constexpr IntegerRange RANGE = IntegerRange::closed_open(0, 16);
+        constexpr CyclesAndInteger RESULT = decrement_index_with_wraparound(RANGE, 3, 5);
+        static_assert(-1 == RESULT.cycles);
+        static_assert(14 == RESULT.integer);
+    }
+    {
+        static constexpr IntegerRange RANGE = IntegerRange::closed_open(0, 16);
+        constexpr CyclesAndInteger RESULT = decrement_index_with_wraparound(RANGE, 8, 8);
+        static_assert(0 == RESULT.cycles);
+        static_assert(0 == RESULT.integer);
+    }
+    {
+        // FixedDeque-style virtual origin. The returned integer must stay in-range.
+        static constexpr IntegerRange RANGE = IntegerRange::closed_open(0, 15);
+        static constexpr std::size_t ORIGIN = (std::numeric_limits<std::size_t>::max)() / 2;
+        constexpr CyclesAndInteger RESULT = decrement_index_with_wraparound(RANGE, ORIGIN, ORIGIN);
+        static_assert(0 == RESULT.integer);
+        static_assert(RESULT.integer < 15);
     }
 }
 

--- a/test/fixed_robinhood_hashtable_test.cpp
+++ b/test/fixed_robinhood_hashtable_test.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <bit>
 #include <cstdint>
 #include <functional>
 #include <iostream>
@@ -876,6 +877,19 @@ TEST(MapCornerCases, PerfectCollisions)
     idx = map.opaque_index_of(24);
     EXPECT_TRUE(map.exists(idx));
     EXPECT_EQ(idx.bucket_index, 6);
+}
+
+TEST(DefaultBucketCount, RoundsUpToPowerOfTwo)
+{
+    static_assert(default_bucket_count(0) == 0);
+    static_assert(default_bucket_count(1) == 1);
+    static_assert(default_bucket_count(2) == 2);
+    static_assert(default_bucket_count(10) == 16);
+    static_assert(default_bucket_count(11) == 16);
+    static_assert(default_bucket_count(32) == 64);
+    static_assert(default_bucket_count(100) == 256);
+    static_assert(std::has_single_bit(default_bucket_count(7)));
+    static_assert(default_bucket_count(10) >= (10 * 130) / 100);
 }
 
 }  // namespace fixed_containers::fixed_robinhood_hashtable_detail


### PR DESCRIPTION
Cuts generated instructions on the hottest `fixed-containers` paths: hash lookup, wraparound indexing, insert/erase relocate, and internal element access.

## Performance

Same `noinline` kernels compiled against `main` and this branch. x86-64, `g++-13 -O3 -DNDEBUG -fno-exceptions`. Instruction counts exclude `endbr64` and alignment nops. Times are median of 7 pinned-core runs.

| Kernel | Instructions (`main` → this PR) | ns/op (`main` → this PR) |
| --- | --- | --- |
| Default 32-entry `FixedUnorderedMap` `find` | 46 → 35 (−24%) | 1.77 → 1.52 (−14%) |
| `uninitialized_relocate` of 32 `int`s | 53 → 5 | 3.98 → 2.69 (−32%) |
| `FixedVector` insert+erase at `begin()+1` (128 `int`s) | 93 → 43 (−54%) | 23.3 → 16.2 (−31%) |
| `wrap_decrement` over `[0, 16)` | 21 → 17 (−19%) | 1.26 → 0.97 (−23%) |
| `wrap_increment` over `[0, 16)` | 5 → 5 | already `lea` + `and` on `main` |

clang++-18 `-O3` instruction counts for the same kernels: map find **39 → 27 (−31%)**, relocate **37 → 5**, vector insert+erase **68 → 46 (−32%)**, wrap decrement **21 → 16**.

Default 32-entry `FixedUnorderedMap` goes from 41 to 64 buckets (`sizeof` 872 → 1056). The lookup probe wrap is `and $0x3f` instead of a multiply-based remainder by 41. Pass an explicit `BUCKET_COUNT` to keep the old table size; that path is unchanged.

Compile-time power-of-two increment was already strength-reduced to AND on both gcc and clang at `-O3`. The new fast path matches that and helps decrement / non-`constexpr` paths. wyhash `r8`/`r4` and iterator `+=` already lowered to a single load / scaled index at `-O3` on `main`.

## Changes

**Robin hood / unordered map & set**
- `default_bucket_count()` now keeps the ~30% oversize, then `std::bit_ceil`s so the table size is a power of two (the existing TODO).
- `bucket_index_from_hash` and `next_bucket_index` become a single `AND` when the table size is a power of two, instead of `%` / compare-and-branch wrap.

Generated lookup probe wrap for a default 32-capacity map is now `and $0x3f` (64 buckets) rather than a multiply-based remainder by 41.

**Circular indexing / deque**
- Fast path for the common `[0, N)` range.
- Power-of-two `FixedDeque` capacities use `(index ± n) & (N-1)`.
- Iterator dereference uses unchecked `operator[]` instead of `std::array::at()`.

`wrap_increment` for N=16 compiles to `lea` + `and $0xf` + `ret`.

**Relocate / iterators / loads**
- `uninitialized_relocate{,_backward}` `memmove`s contiguous trivially-copyable ranges at runtime (used by `FixedVector` insert/erase).
- Tighter `lexicographical_compare_three_way` loop.
- Random-access iterators increment the underlying iterator directly instead of `std::advance`.
- wyhash `r8`/`r4` use `memcpy` (one unaligned load) instead of `copy_n` into a temporary `std::array`.
- Internal `std::array::at()` / `FixedVector::at()` on already-validated indexes (`EnumArray`, linked-list chain, contiguous tree storage) go through unchecked access.

## Layout note

Default `FixedUnorderedMap` / `FixedUnorderedSet` bucket counts change (always ≥ the old 130% size, rounded up to a power of two). Instances used as NTTPs or serialized by raw layout will have a different `sizeof`. Pass an explicit `BUCKET_COUNT` to keep a specific size.

## Tests

- New `test/algorithm_test.cpp` for relocate, three-way compare, and contiguous `FixedVector` iterators.
- Extra wraparound cases, including the FixedDeque-style virtual origin near `SIZE_MAX/2`.
- `default_bucket_count` static_asserts.

Ran locally with g++-13 / clang-18: `circular_indexing`, `algorithm`, `fixed_robinhood_hashtable`, `fixed_vector`, `fixed_deque`, `fixed_unordered_{map,set}`, `fixed_circular_{deque,queue}`, `fixed_{string,list,queue,stack,bitset}`, `int_math`, `integer_range`.